### PR TITLE
test: remove unnecessary bunfig.toml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -149,7 +149,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.68", "", { "os": "win32", "cpu": "x64" }, "sha512-2+bgC7ujhcx2XEl7sCdYAT6BIB7Y4eN5LuCII2p14gtQbvqBi7gFgd/UphLobarbSxhmaU/6D5cdSL2G0Yk2hQ=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-05" }, "bin": { "playwright": "cli.js" } }, "sha512-d3R1qrHgKIpuvZeVDbSc6YfUWv5GXgAevKDX/xHZCqVJwY+BPNqjnnl3MmbgAUj5pO90bS6B2HlziyvZyo3emA=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-06" }, "bin": { "playwright": "cli.js" } }, "sha512-d8EVgj2aFLWq7anFJbFg/2TbvaygUrK2SjaN+EhqvRi+KBIOO8z+W6AahJh6gWNUgtHNCCpWTOaCjgScdooi0Q=="],
 
     "@rspack/binding": ["@rspack/binding@1.3.12", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.3.12", "@rspack/binding-darwin-x64": "1.3.12", "@rspack/binding-linux-arm64-gnu": "1.3.12", "@rspack/binding-linux-arm64-musl": "1.3.12", "@rspack/binding-linux-x64-gnu": "1.3.12", "@rspack/binding-linux-x64-musl": "1.3.12", "@rspack/binding-win32-arm64-msvc": "1.3.12", "@rspack/binding-win32-ia32-msvc": "1.3.12", "@rspack/binding-win32-x64-msvc": "1.3.12" } }, "sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg=="],
 
@@ -317,9 +317,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-05" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-CKODBN4QyCOPZVr4DQT77P8gmJ8bD3EZTO6f0T2nJ8YJYcjhfSd9xUjybmCmIw1q5gfCiwCAgp6Ed0iLhXZYoA=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-06" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-LoxuPYLnhxcizhOvE8ycVOOfjKsNkBAFyb3XsAbDjKBCPjHkEJ+LvxgSTqZnkJMubZ4E0eioKpFN8jrX8Gjt5Q=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-05", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-IsuKgjfwsRqC5x3pQ/X+IJBj8zFOzKbxDmWjO8OIQKMzPDyoFCCYrI4lqOAYZ4ffmZeBdNXEu93ZrS+NYhduWA=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-06", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-L57Jn2+3Q90cU3OtRqJbHxryrMnANJJ075UltpXMEmvur/zbXNe5R2t798gcco3eWmjrBqL7Bc9MK0xKjG6tXQ=="],
 
     "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[test]
-preload = "./happydom.tsx"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check --write",
-    "test:app": "bun test test/app",
+    "test:app": "bun test test/app --preload ./happydom.tsx",
     "test:e2e": "playwright test",
     "test:report": "playwright show-report"
   },


### PR DESCRIPTION
## Summary by Sourcery

Remove the unused bunfig.toml file and update the `test:app` script to preload happy-dom.

Enhancements:
- Add `--preload ./happydom.tsx` flag to the `test:app` npm script.

Chores:
- Delete unnecessary bunfig.toml configuration file.