### PR TITLE
chore: version up autofix ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,6 +33,6 @@ jobs:
         run: bun lint && bunx biome ci --reporter=github
 
       - name: 💾 Commit
-        uses: autofix-ci/action@v1.3.1
+        uses: autofix-ci/action@v1.3.2
         with:
           commit-message: "fix(autofix.ci): apply automated fixes"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update autofix-ci/action from v1.3.1 to v1.3.2 in .github/workflows/autofix.yml