### PR TITLE
build: 🆙 update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,12 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+
 updates:
   - package-ecosystem: "bun"
     directory: "/"
@@ -11,33 +19,15 @@ updates:
       dependencies:
         patterns:
           - "*"
+
   - package-ecosystem: "devcontainers"
     directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    groups:
-      devcontainers:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "infrastructure"
+
   - package-ecosystem: "docker"
     directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    groups:
-      docker:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "infrastructure"
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "ci"
-    groups:
-      ci:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "infrastructure"

--- a/bun.lock
+++ b/bun.lock
@@ -131,25 +131,25 @@
 
     "@module-federation/webpack-bundler-runtime": ["@module-federation/webpack-bundler-runtime@0.14.0", "", { "dependencies": { "@module-federation/runtime": "0.14.0", "@module-federation/sdk": "0.14.0" } }, "sha512-POWS6cKBicAAQ3DNY5X7XEUSfOfUsRaBNxbuwEfSGlrkTE9UcWheO06QP2ndHi8tHQuUKcIHi2navhPkJ+k5xg=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.80", "", {}, "sha512-+AzGTOE4QBP/mrgAOyLT0lu8y5GUZPySL1DhfsBHrnUZYfGnOGR6tiKkHG1bKyq5EC2UDmwKMbRan8Np2mb1Yg=="],
+    "@next/env": ["@next/env@15.4.0-canary.81", "", {}, "sha512-mZm/pjWbNdnPKrUgw06nJdXrj7J4NTUe9y5avba3vo1/ejCEu8lM4vzKm6cxEXN1FQ/jQ1/wlwrTumNyfRxHLA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.80", "", { "os": "darwin", "cpu": "arm64" }, "sha512-x06LWg5vr9JhXysBXgOhzSUQG3M/r7gn2hAoXJC/mYC2m+eWkmp6ZVhX/Vgj6j98XU21yPRPukOmiq2Qf5sd2Q=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.81", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pfT4uFmS1l393jeaipXqzuPuBk3kUZbZ3C3CODEB68jqlUhZ8dn3HlaHpVCOwGy73a2JFm64Hy9m06PV8YLomQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.80", "", { "os": "darwin", "cpu": "x64" }, "sha512-KesWywliY7SJdK5m6fEMEoK97r1k+63U4yiaPbeCvD8j8HAuAu+vb3WO8GsDuJu9c6Uur3lV50SWev2QqSLzNg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.81", "", { "os": "darwin", "cpu": "x64" }, "sha512-5+5V4Ep59G9i9pni+3TMlau6EAKCkbgMJAJ623+V9u9eoH8Dap1zzHxCZf9wyUoRIItEdzHT3P2PPDEnbWdAKQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-6V71RXjg7Bh/lB/EnvxZAPOuUvjOzaKh5CtI323zGmPsiwMeU7XdDMsamUE4Sa0ogYQkrR/u8sWP8mRFfvDTyQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.81", "", { "os": "linux", "cpu": "arm64" }, "sha512-QJfekBh5a4CM/IdyiPRgnsI6PTjGaXDzjY0d0nTjDoAuHrZfQFSqZXNJu8e2zKanQiVeY8QibAMfRIc0RPLvag=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-MkNNk9peIpgnsiPyeJzdN83N5M5NxW3o9H46kLb7XPlH6sJAhGjiJJagOwXFiA25T5i1FScCjFI472ADT8PRUQ=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.81", "", { "os": "linux", "cpu": "arm64" }, "sha512-oPiWrylTZNRtSGT9nVFZiv2srpGBzD66WfahZGnWJUPk0saM/0sqtMHNUTdC7EGvyfL/g1bMuBeHbTW94qrBHA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.80", "", { "os": "linux", "cpu": "x64" }, "sha512-1/k5qKqVmcB/IPJ5pdFML1VIDk1WNEmHe7MxJbLxhXLWjrclb+IqlTagzvaM3BPvrJV/ETVHtgbfYFEJZPYNPg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.81", "", { "os": "linux", "cpu": "x64" }, "sha512-g7GiEZtbsQGmhSufH24rFkyhBr1nlJ5cUqw4oHoOu3yYGxe6XaU9+OZr17gQRxdrQxeQz6sV/rfrsB9InvD/gA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.80", "", { "os": "linux", "cpu": "x64" }, "sha512-Ex1x9asSo3IuuQ6lynxcRtXSlrQeIz1ulKsaCpKVu6vnT6b+nJH0hvazKZff5cdWAcGRoeNML2RfBRf2lXcooA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.81", "", { "os": "linux", "cpu": "x64" }, "sha512-K5tTx9WPru+39xq34mCMzarzC2x8z4ltLB68Cst6kjKgoynuzU3WKXRR4XPeSuKciDnamtDfhO8B0tNV5sLxeA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.80", "", { "os": "win32", "cpu": "arm64" }, "sha512-encLMMFy38y87cHON2HlOr88uWgWYE7rn4LcG0UYmRnX8yU1IChXuFqxNZmz9zWVIZ1Pgliul11bytrldlhROg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.81", "", { "os": "win32", "cpu": "arm64" }, "sha512-kJz1Sjr4cUYJtDwXoqooJhvxgn5XcAaD8n/6i2oG+zRWxOIKHq5KFJY/U8Hai5PlrAGNWFAf9DpM4Xic5vPL/g=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.80", "", { "os": "win32", "cpu": "x64" }, "sha512-7aVDQ85JT93eld5p6FShhkTMqvsOFjYjKo4/H36jHCYyHvYzTacDU7MUP3IRTzPzsn+5exAD9EFEH4tHsLtPZA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.81", "", { "os": "win32", "cpu": "x64" }, "sha512-e/0OYH3k69Jx6u/QENoqGTFKhKjj2OuEPKRM16QqXhSFsFSjtg63njqmSuAC4IZxPZw0xDN9+0FgPn4X9CvfxQ=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-12", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-12" }, "bin": { "playwright": "cli.js" } }, "sha512-Aee4NEo845rF9+4WX58mnMgrP01qfhwLRth1wjVzbqHPJy0YmOSvgh/vv1LXc9cPNZTziPabZrEi5b5JoCDMGQ=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-13", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-13" }, "bin": { "playwright": "cli.js" } }, "sha512-MGh/kgaBuRvB5vkR3z+1hQCAqeGlx7ZPc8B1E7U5CkifpChdHNQAQ2mPvEG+oIE1YwUS8uHU16VUg/KtsiNa0w=="],
 
     "@rspack/binding": ["@rspack/binding@1.3.12", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.3.12", "@rspack/binding-darwin-x64": "1.3.12", "@rspack/binding-linux-arm64-gnu": "1.3.12", "@rspack/binding-linux-arm64-musl": "1.3.12", "@rspack/binding-linux-x64-gnu": "1.3.12", "@rspack/binding-linux-x64-musl": "1.3.12", "@rspack/binding-win32-arm64-msvc": "1.3.12", "@rspack/binding-win32-ia32-msvc": "1.3.12", "@rspack/binding-win32-x64-msvc": "1.3.12" } }, "sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg=="],
 
@@ -231,7 +231,7 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-87dbe21-20250611", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-oUFDpcuwFy3KIzosOrQ5X8cFbExVx1VvX9OVaF8Z1UL2ePOVEutr8AgZ7lZxjjhWWoyMlW1LxI/Hs/DxPMdONA=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4b12060-20250611", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-KZoKh/QEXot6EKzC/N63PS1cPp2NFaVjmgEe8iSYwRsgisB89KUlIlHqyb8E88bSLMv38oY8L7hcqdAmo52nog=="],
 
     "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
 
@@ -313,15 +313,15 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.0-canary.80", "", { "dependencies": { "@next/env": "15.4.0-canary.80", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.80", "@next/swc-darwin-x64": "15.4.0-canary.80", "@next/swc-linux-arm64-gnu": "15.4.0-canary.80", "@next/swc-linux-arm64-musl": "15.4.0-canary.80", "@next/swc-linux-x64-gnu": "15.4.0-canary.80", "@next/swc-linux-x64-musl": "15.4.0-canary.80", "@next/swc-win32-arm64-msvc": "15.4.0-canary.80", "@next/swc-win32-x64-msvc": "15.4.0-canary.80", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-OTxgtG7gjsYY2AlHVQBlWC7pI4uqNVdeKpFsCgdH3bqArMO74GsuVE9r/1ezJqK3jMp8upaxSkxbHL100jFG+w=="],
+    "next": ["next@15.4.0-canary.81", "", { "dependencies": { "@next/env": "15.4.0-canary.81", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.81", "@next/swc-darwin-x64": "15.4.0-canary.81", "@next/swc-linux-arm64-gnu": "15.4.0-canary.81", "@next/swc-linux-arm64-musl": "15.4.0-canary.81", "@next/swc-linux-x64-gnu": "15.4.0-canary.81", "@next/swc-linux-x64-musl": "15.4.0-canary.81", "@next/swc-win32-arm64-msvc": "15.4.0-canary.81", "@next/swc-win32-x64-msvc": "15.4.0-canary.81", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-Hr88OWLSGacyM6TVzL0s9VsFdyAU84ZJZUXsuEd3OoNlbGT5aWNvYFjz49HfKty86zr+Esx13TDWTYaKfWwuFw=="],
 
-    "next-rspack": ["next-rspack@15.4.0-canary.80", "", { "dependencies": { "@rspack/core": "1.3.12", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-llCj4nKpGIydYWcBdRLj2hUK6eMH/bauOoX7su5FtJz66IE+v1+OxKgav3jVL8SXjC4yA0+mfMC5WFcY5gyr0g=="],
+    "next-rspack": ["next-rspack@15.4.0-canary.81", "", { "dependencies": { "@rspack/core": "1.3.12", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-sjJ6QA+BWhNwQpnlnzKVRN7JAdCU5V8gP1OuRvaGk15O8caiD7+mieLHrVHNTGUBtYpz8GaX4y5RDQzE3NIuMw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-12", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-12" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-O/IyiFmkRcIjxXquKPbwJmXK+jkCUFYDob9D29zbsdR1mWZ9fS6ZRN3NumBfw6JkJDlcADTu2DEziuY6rVHhkw=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-13", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-13" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-N68oVsL16l6kq09xFgmc8BrdlZzRSdu22xKp3YFFRqYZHPx2osvJ2jZOp+Z7R7MxcmOF5H0KaqSr4FhrPtBObw=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-12", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-B11EEdc+U0vZ1Hpzeuy5Mo+LgMiMzy5lWY1QJGcSYw2HPTb9hhGUEpiY43gFw6tXhxtOwbAiz5AmxG+ZlFNJBA=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-13", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-tZvMgubK6vLxa2RoHRv4KaldT4FIyd5QygB2wNQqDGI6dgbSvwlNfQCbLW/vC8N4fddnde0oBUNv5E6vhdapsw=="],
 
     "postcss": ["postcss@8.5.5", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Centralize dependency updates by introducing an "infrastructure" multi-ecosystem group in Dependabot configuration and refresh the Bun lockfile.

Build:
- Add an "infrastructure" multi-ecosystem group with a daily schedule and chore commit-message prefix
- Replace individual Dependabot schedules and group definitions for bun, devcontainers, docker, and GitHub Actions with the new infrastructure group

Chores:
- Update bun.lock to reflect refreshed dependencies