### PR TITLE
ci: remove checkout action from lambda.yml

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -25,7 +25,6 @@ on:
         type: boolean
 
 permissions:
-  contents: read
   id-token: write
 
 env:
@@ -40,15 +39,6 @@ jobs:
     if: github.repository_owner == 'jambalaya56562'
 
     steps:
-    - name: 📥 Checkout
-      uses: actions/checkout@v4
-
-    - name: 🐦‍⬛ Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: 🛠️ Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: 🪪 Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -65,12 +55,17 @@ jobs:
         echo "OLD_IMAGE_TAG=$(aws ecr list-images --repository-name $ECR_REPOSITORY \
         --query 'imageIds[0].imageTag' --output text)" >> $GITHUB_ENV
 
+    - name: 🐦‍⬛ Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: 🛠️ Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: 🚀 Build and Push
       uses: docker/build-push-action@v6
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        context: .
         no-cache: ${{ inputs.no-cache == true }}
         platforms: linux/arm64
         provenance: false


### PR DESCRIPTION
## Summary by Sourcery

Clean up the lambda CI workflow by removing the unnecessary checkout and redundant permissions, repositioning QEMU and Buildx setup steps, and simplifying the Docker build-push configuration.

CI:
- Remove initial checkout, QEMU, and Buildx setup steps from the start of the lambda workflow
- Reposition QEMU and Docker Buildx setup to immediately precede the Docker build
- Eliminate explicit context specification from the Docker build-push action
- Drop redundant contents: read permission from the workflow