### PR TITLE
ci: change compare image on docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -128,5 +128,5 @@ jobs:
         with:
           command: compare
           image: ${{ steps.meta.outputs.tags }}
-          to: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}:canary
+          to: ${{ env.REPOSITORY }}:canary
           only-severities: critical,high


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use the REPOSITORY environment variable instead of GHCR_REGISTRY and GHCR_REPOSITORY for the compare step destination image