### PR TITLE
ci: fix docker context

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPOSITORY: jambalaya56562/blog
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  CONTEXT: ${{ github.server_url }}/${{ github.repository }}.git#${{ github.sha }}
   IS_PUSH: ${{ github.event_name == 'push' || inputs.push == true }}
 
 jobs:
@@ -62,6 +63,12 @@ jobs:
     if: github.repository_owner == 'jambalaya56562'
 
     steps:
+      - name: 📥 Checkout
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SHA }}
+
       - name: 🐋 Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -106,6 +113,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          context: ${{ github.event_name == 'pull_request_target' && env.CONTEXT || '.' }}
           labels: ${{ steps.meta.outputs.labels }}
           load: ${{ !fromJSON(env.IS_PUSH) }}
           no-cache: ${{ inputs.no-cache == true }}


### PR DESCRIPTION
## Summary by Sourcery

Fix Docker build context resolution in GitHub Actions by setting a proper CONTEXT variable and ensuring source code is checked out for non pull_request_target events

CI:
- Introduce CONTEXT environment variable to reference the repository URL and commit SHA
- Add actions/checkout step for non pull_request_target events to provide source code for Docker builds
- Update docker/build-push action to use the remote CONTEXT for pull_request_target events and local context otherwise