### PR TITLE
ci: add pull-request-title-lint action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,7 @@ jobs:
 
             [![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
 
-            *Run & review this pull request in [StackBlitz Codeflow](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }}).*
+            *Learn more about [StackBlitz Codeflow](https://stackblitz.com/codeflow/).*
             <!-- generated-comment [Preview]($WORKFLOW_REF) -->`
 
             if (!previewComment) {

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -1,0 +1,104 @@
+name: ✨ Check Conventional Commit Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 👀 Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+
+      - name: ❌ Add a lint comment
+        uses: actions/github-script@v7
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const lintTitleComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('# ❌ Pull Request Title Linting Failed')
+            })
+            const body = `# ❌ Pull Request Title Linting Failed
+
+            Thank you for opening this pull request 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            \`\`\`yaml
+            ${JSON.stringify(steps.lint_pr_title.outputs.error_message)}
+            \`\`\`
+
+            Please update the title of this pull request to follow the specification.
+            <!-- generated-comment [Title-Lint]($WORKFLOW_REF) -->`
+
+            if (!lintTitleComment) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              })
+            }
+
+      - name: ✅ Add a Fixed comment
+        uses: actions/github-script@v7
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const lintTitleComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('# ❌ Pull Request Title Linting Failed')
+            })
+            const body = `# ✅ Pull Request Title Linting Passed
+
+            Thank you for updating the title of this pull request to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+            <!-- generated-comment [Title-Lint]($WORKFLOW_REF) -->`
+
+            if (lintTitleComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: lintTitleComment.id,
+              })
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              })
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,11 @@ jobs:
             <!-- generated-comment [Test]($WORKFLOW_REF) -->`
 
             if (testComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: testComment.id,
+              })
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a pull-request-title-lint workflow to validate PR titles against Conventional Commits