### PR TITLE
test: check ci

### DIFF
--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -36,6 +36,8 @@ jobs:
       - name: ❌ Add a lint comment
         uses: actions/github-script@v7
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        env:
+          ERROR_MESSAGE: ${{ steps.lint_pr_title.outputs.error_message }}
         with:
           script: |
             const { data: comments } = await github.rest.issues.listComments({
@@ -55,7 +57,7 @@ jobs:
             Details:
 
             \`\`\`yaml
-            ${JSON.stringify(steps.lint_pr_title.outputs.error_message)}
+            ${process.env.ERROR_MESSAGE}
             \`\`\`
 
             Please update the title of this pull request to follow the specification.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: 💬 Create test comment
-        if: github.event_name == 'pull_request' && env.STATUS == 1
+        if: github.event_name == 'pull_request_target' && env.STATUS == 1
         env:
           ACTOR: ${{ github.actor }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary by Sourcery

Improve GitHub Actions workflows for PR title linting and test comment generation

CI:
- Export lint error message to an environment variable and reference it via process.env in the PR title lint workflow
- Update the test comment step to trigger on pull_request_target instead of pull_request