### PR TITLE
ci: use workflow_call

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,13 +1,20 @@
 name: 💬 Comment on the pull request
 
 on:
-  workflow_run:
-    workflows:
-      - 📝 Check Conventional Commit
-      - ✨ Check Conventional Commit Title
-      - 🧪 Test
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      comment:
+        description: "Comment to add to the pull request"
+        required: true
+        type: string
+      pr_number:
+        description: "Pull request number"
+        required: true
+        type: string
+      title:
+        description: "Pull request title"
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
@@ -15,40 +22,13 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
     steps:
-      - name: 📥 Download comment
-        uses: actions/download-artifact@v4
-        with:
-          name: comment.txt
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: 📥 Download pull request number
-        uses: actions/download-artifact@v4
-        with:
-          name: pr_number.txt
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: 📥 Download title
-        uses: actions/download-artifact@v4
-        with:
-          name: title.txt
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: ⚙️ Setup Environment
-        run: |
-          echo "PR_NUMBER=$(cat pr_number.txt | tr -cd '0-9')" >> $GITHUB_ENV
-          echo "TITLE=$(cat title.txt)" >> $GITHUB_ENV
-          UUID=$(uuidgen)
-          {
-            echo "COMMENT<<EOF_$UUID"
-            cat comment.txt
-            echo "EOF_$UUID"
-          } >> "$GITHUB_ENV"
-
       - name: 💬 Add a comment
         uses: actions/github-script@v7
         env:
+          COMMENT: ${{ inputs.comment }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          TITLE: ${{ inputs.title }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,14 +65,10 @@ jobs:
             echo "EOF_$UUID"
           } >> $GITHUB_OUTPUT
 
-      - name: 💔 Fail if test failed
-        if: steps.test.outputs.did_fail == '1'
-        run: exit 1
-
-  upload:
+  create_comment:
     runs-on: ubuntu-latest
     needs: test
-    if: always() && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment
@@ -85,22 +81,24 @@ jobs:
           TEST_LOG: ${{ needs.test.outputs.test_log }}
         run: |
           UUID=$(uuidgen)
-          cat <<EOF_$UUID > comment.txt
-          # ❌ Test Failed
-          @$ACTOR, your commit $SHA failed the test.
-
-          <details>
-          <summary><strong>Test Log</strong></summary>
-
-          \`\`\`shell
-          $TEST_LOG
-          \`\`\`
-
-          </details>
-
-          👀[View in Actions](https://github.com/$REPO/actions/runs/$RUN_ID)
-          <!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->
-          EOF_$UUID
+          {
+            echo "COMMENT<<EOF_$UUID"
+            echo "# ❌ Test Failed"
+            echo "@$ACTOR, your commit $SHA failed the test."
+            echo ""
+            echo "<details>"
+            echo "<summary><strong>Test Log</strong></summary>"
+            echo ""
+            echo "\`\`\`shell"
+            echo "$TEST_LOG"
+            echo "\`\`\`"
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "👀[View in Actions](https://github.com/$REPO/actions/runs/$RUN_ID)"
+            echo "<!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->"
+            echo "EOF_$UUID"
+          } >> $GITHUB_ENV
 
       - name: ✅ Create test success comment
         if: needs.test.outputs.did_fail == '0'
@@ -108,31 +106,27 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           UUID=$(uuidgen)
-          cat <<EOF_$UUID > comment.txt
-          # ✅ Test Passed
-          Failed tests were fixed.
-          <!-- generated-comment [Comment](https://github.com/$REPO/.github/workflows/comment.yml) -->
-          EOF_$UUID
+          {
+            echo "COMMENT<<EOF_$UUID"
+            echo "# ✅ Test Passed"
+            echo "All tests passed successfully."
+            echo ""
+            echo "<!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->"
+            echo "EOF_$UUID"
+          } >> $GITHUB_ENV
 
-      - name: 🔢 Create pull request number and title
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: 🏳️ Set up comment title
+        id: title
         run: |
-          echo "$PR_NUMBER" > pr_number.txt
-          echo "# ❌ Test Failed" > title.txt
+          echo "title=# ❌ Test Failed" >> $GITHUB_OUTPUT
 
-      - name: 🆙 Upload test comment
-        uses: actions/upload-artifact@v4
+      - name: 💬 Add a comment
+        uses: ./.github/workflows/comment.yml
         with:
-          name: comment.txt
-          path: comment.txt
-      - name: 🆙 Upload pull request number
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr_number.txt
-          path: pr_number.txt
-      - name: 🆙 Upload title
-        uses: actions/upload-artifact@v4
-        with:
-          name: title.txt
-          path: title.txt
+          comment: ${{ env.COMMENT }}
+          pr_number: ${{ github.event.pull_request.number }}
+          title: ${{ steps.title.outputs.title }}
+
+      - name: 💔 Fail if test failed
+        if: steps.test.outputs.did_fail == '1'
+        run: exit 1


### PR DESCRIPTION
## Summary by Sourcery

Refactor the existing comment workflow into a reusable workflow_call and update the test workflow to leverage it directly, eliminating artifact uploads and workflow_run triggers

Enhancements:
- Convert comment.yml into a reusable workflow_call with explicit inputs for comment text, PR number, and title
- Update test workflow to generate comment content in environment variables and invoke the reusable comment workflow instead of uploading artifacts
- Reorder steps so that comments are posted before failing the job

CI:
- Switch comment workflow trigger from workflow_run to workflow_call
- Simplify conditional logic for the create_comment job