### PR TITLE
ci: use workflow_run

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,20 +1,13 @@
 name: 💬 Comment on the pull request
 
 on:
-  workflow_call:
-    inputs:
-      comment:
-        description: "Comment to add to the pull request"
-        required: true
-        type: string
-      is_success:
-        description: "Indicates if the previous job succeeded"
-        required: true
-        type: boolean
-      title:
-        description: "Pull request title"
-        required: true
-        type: string
+  workflow_run:
+    workflows:
+      - 📝 Check Conventional Commit
+      - ✨ Check Conventional Commit Title
+      - 🧪 Test
+    types:
+      - completed
 
 permissions:
   pull-requests: write
@@ -22,19 +15,47 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
+      - name: 📥 Download comment
+        uses: actions/download-artifact@v4
+        with:
+          name: comment.txt
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: 📥 Download pull request number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_number.txt
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: 📥 Download title
+        uses: actions/download-artifact@v4
+        with:
+          name: title.txt
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: ⚙️ Setup Environment
+        run: |
+          echo "PR_NUMBER=$(cat pr_number.txt | tr -cd '0-9')" >> $GITHUB_ENV
+          echo "TITLE=$(cat title.txt)" >> $GITHUB_ENV
+          UUID=$(uuidgen)
+          {
+            echo "COMMENT<<EOF_$UUID"
+            cat comment.txt
+            echo "EOF_$UUID"
+          } >> "$GITHUB_ENV"
+
       - name: 💬 Add a comment
         uses: actions/github-script@v7
         env:
-          COMMENT: ${{ inputs.comment }}
-          IS_SUCCESS: ${{ inputs.is_success }}
-          TITLE: ${{ inputs.title }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
           script: |
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: process.env.PR_NUMBER,
             })
             const oldComment = comments.find(comment => {
               return comment.user.type === 'Bot' && comment.body.includes(process.env.TITLE)
@@ -48,16 +69,16 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: process.env.PR_NUMBER,
                 body: process.env.COMMENT
               })
               return
             }
-            if (process.env.IS_SUCCESS === 'false') {
+            if (process.env.CONCLUSION === 'failure') {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: process.env.PR_NUMBER,
                 body: process.env.COMMENT
               })
             }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         if: steps.test.outputs.is_success == 'false'
         run: exit 1
 
-  create_comment:
+  upload:
     runs-on: ubuntu-latest
     needs: test
     outputs:
@@ -89,24 +89,22 @@ jobs:
           TEST_LOG: ${{ needs.test.outputs.test_log }}
         run: |
           UUID=$(uuidgen)
-          {
-            echo "comment<<EOF_$UUID"
-            echo "# ❌ Test Failed"
-            echo "@$ACTOR, your commit $SHA failed the test."
-            echo ""
-            echo "<details>"
-            echo "<summary><strong>Test Log</strong></summary>"
-            echo ""
-            echo "\`\`\`shell"
-            echo "$TEST_LOG"
-            echo "\`\`\`"
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "👀[View in Actions](https://github.com/$REPO/actions/runs/$RUN_ID)"
-            echo "<!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->"
-            echo "EOF_$UUID"
-          } >> $GITHUB_OUTPUT
+          cat <<EOF_$UUID > comment.txt
+          # ❌ Test Failed
+          @$ACTOR, your commit $SHA failed the test.
+
+          <details>
+          <summary><strong>Test Log</strong></summary>
+
+          \`\`\`shell
+          $TEST_LOG
+          \`\`\`
+
+          </details>
+
+          👀[View in Actions](https://github.com/$REPO/actions/runs/$RUN_ID)
+          <!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->
+          EOF_$UUID
 
       - name: ✅ Create test success comment
         if: needs.test.outputs.is_success == 'true'
@@ -115,29 +113,31 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           UUID=$(uuidgen)
-          {
-            echo "comment<<EOF_$UUID"
-            echo "# ✅ Test Passed"
-            echo "All tests passed successfully."
-            echo ""
-            echo "<!-- generated-comment [Test](https://github.com/$REPO/.github/workflows/test.yml) -->"
-            echo "EOF_$UUID"
-          } >> $GITHUB_OUTPUT
+          cat <<EOF_$UUID > comment.txt
+          # ✅ Test Passed
+          Failed tests were fixed.
+          <!-- generated-comment [Comment](https://github.com/$REPO/.github/workflows/comment.yml) -->
+          EOF_$UUID
 
-      - name: 🏳️ Set up comment title
-        id: title
+      - name: 🔢 Create pull request number and title
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "title=# ❌ Test Failed" >> $GITHUB_OUTPUT
+          echo "$PR_NUMBER" > pr_number.txt
+          echo "# ❌ Test Failed" > title.txt
 
-  add_comment:
-    needs:
-      - create_comment
-      - test
-    permissions:
-      pull-requests: write
-    if: always() && github.event_name == 'pull_request'
-    uses: ./.github/workflows/comment.yml
-    with:
-      comment: ${{ needs.create_comment.outputs.comment }}
-      is_success: ${{ needs.test.outputs.is_success == 'true' }}
-      title: ${{ needs.create_comment.outputs.title }}
+      - name: 🆙 Upload test comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment.txt
+          path: comment.txt
+      - name: 🆙 Upload pull request number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number.txt
+          path: pr_number.txt
+      - name: 🆙 Upload title
+        uses: actions/upload-artifact@v4
+        with:
+          name: title.txt
+          path: title.txt


### PR DESCRIPTION
## Summary by Sourcery

Decouple test and comment workflows by switching the comment action to a workflow_run trigger and passing comment data via artifacts instead of workflow_call inputs

CI:
- Replace workflow_call with workflow_run in comment.yml and restrict execution to pull_request events
- Generate comment content, PR number, and title files in the test job and upload them as artifacts
- Download those artifacts in the comment workflow and use workflow_run.conclusion with actions/github-script to post pull request comments