### PR TITLE
ci: update wrong step name

### DIFF
--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -32,7 +32,7 @@ jobs:
           echo 'export default { extends: ["@commitlint/config-conventional"],
           ignores: [(message: string) => message.includes("Signed-off-by: dependabot[bot]")] }' > commitlint.config.ts
 
-      - name: 👀 Validate PR commits with commitlint
+      - name: 👀 Validate PR title with commitlint
         if: github.event_name == 'pull_request'
         id: commitlint
         env:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Rename the GitHub Actions step from 'Validate PR commits with commitlint' to 'Validate PR title with commitlint'