### PR TITLE
ci: replace the all `bunx` with `bun`

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun update
 
       - name: 🔷 Run Biome
-        run: bun check && bunx biome ci --reporter=github
+        run: bun check
 
       - name: 💾 Commit
         uses: autofix-ci/action@v1.3.2

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: 👀 Validate current commit (last commit) with commitlint
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: bunx commitlint --last --verbose
+        run: bun commitlint --last --verbose
 
       - name: 👀 Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
@@ -47,7 +47,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          bunx commitlint --from $BASE_SHA --to $HEAD_SHA --verbose \
+          bun commitlint --from $BASE_SHA --to $HEAD_SHA --verbose \
           &> >(tee -p commitlint.log) || STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo "is_success=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -56,10 +56,10 @@ jobs:
         run: bun run build
 
       - name: 🎭 Install Playwright Browsers
-        run: bunx playwright install --with-deps
+        run: bun playwright install --with-deps
 
       - name: 🧪 Run Playwright tests
-        run: bunx playwright test
+        run: bun playwright test
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "$TITLE" | bunx commitlint --verbose &> >(tee -p commitlint.log) || STATUS=$?
+          echo "$TITLE" | bun commitlint --verbose &> >(tee -p commitlint.log) || STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo "is_success=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary by Sourcery

Use the bun CLI directly in GitHub workflows instead of the separate bunx wrapper and streamline the autofix step

CI:
- Replace all bunx command invocations with bun in commitlint, Playwright, and PR title lint workflows
- Remove the bunx biome ci step and only run bun check in the autofix workflow