### PR TITLE
ci: update happydom.tsx filename

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,7 @@ docker:
   - any-glob-to-any-file: ['.devcontainer/*', '.editorconfig', 'biome.json']
 ✅test:
 - changed-files:
-  - any-glob-to-any-file: ['happydom.ts', 'test/**']
+  - any-glob-to-any-file: ['happydom.tsx', 'test/**']
 🆚vscode:
 - changed-files:
   - any-glob-to-any-file: '.vscode/*'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change test labeler rule in .github/labeler.yml to match 'happydom.tsx'