### PR TITLE
ci: remove emoji from dependencies label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,7 @@
 ⚙️config:
 - changed-files:
   - any-glob-to-any-file: '*config.*'
-📦dependencies:
+dependencies:
 - changed-files:
   - any-glob-to-any-file: ['bun.lock', 'package.json']
 docker:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,7 +11,7 @@ changelog:
         - 📝documentation
     - title: 🆙 Version Up
       labels:
-        - 📦dependencies
+        - dependencies
     - title: ✅ Test
       labels:
         - ✅test


### PR DESCRIPTION
## Summary by Sourcery

Remove the package emoji from dependency labels in GitHub workflows to keep label names consistent.

CI:
- Remove 📦 emoji prefix from the dependencies label in .github/labeler.yml
- Remove 📦 emoji prefix from the dependencies label in .github/release.yml