### PR TITLE
ci: version up checkout action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🐣 Install bun

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: 📥 Checkout
         if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.SHA }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.SHA }}
         env:

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🐣 Install bun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: ✅ Check if the release has already been created
         run: echo RELEASE_EXISTS=$(gh release list | grep "$VERSION") >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@v2

--- a/bun.lock
+++ b/bun.lock
@@ -137,7 +137,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.38", "", { "os": "win32", "cpu": "x64" }, "sha512-RHmAzerwYuzgvXjgXzfkiVa+pwvYAIOM85G8xf2RasU3ZcEhSy0NHBrhU78ypJ+pStUxqWvrkWkSxufmD18yRQ=="],
 
-    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-11", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-11" }, "bin": { "playwright": "cli.js" } }, "sha512-Z9W4qgiKDwksELZcw9Z7/t+T7GQRzdBlK+Lj2ZTgftuPDEc6sEfMZLrWOMcCZ9A6wJLsa0SaM77LF/BslzfdNA=="],
+    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-12", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-12" }, "bin": { "playwright": "cli.js" } }, "sha512-lyq9MDSd4UcOWx5292AYLBfbYYCstg8iLb+lk6LdM69ps6bwmPloZO3Ol3JO3FQQ63qAuW9VD0w+ZYKL0lRmQA=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -271,9 +271,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.55.0-alpha-2025-08-11", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-11" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-nx+/ic0l6jw1DCAvZFzxObpiQJIn9q6XgUZBbHNNWRU3CLTBEDzvkOhsRo3U+u1pMjSy0ypXxsq9Q9qijbnDzA=="],
+    "playwright": ["playwright@1.55.0-alpha-2025-08-12", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-12" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-daZPM5gX0VTG6ae3/qOpEKc9NxoavkM2lfL0UIzTG0k+yK8ZeSPYo63iewZhVANsWRm0BT+XQ1NniAUOwWQ+xA=="],
 
-    "playwright-core": ["playwright-core@1.55.0-alpha-2025-08-11", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-7uuIpLYOGwwlPeK4Yj3nqGsnJqCMHcs9QaIx+xrmijbez71kZnXxvREFqLt1KkvIOEt2jazQc1ppCZdAki629A=="],
+    "playwright-core": ["playwright-core@1.55.0-alpha-2025-08-12", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-4uxOd9xmeF6gqdsORzzlXd7p795vcACOiAGVHHEiTuFXsD83LYH+0C/SYLWB0Z+fAq4LdKGsy0qEfTm0JkY8Ig=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the GitHub actions/checkout action to version 5 across all workflows and update the Bun lockfile

CI:
- Bump actions/checkout from v4 to v5 in all CI workflows

Chores:
- Regenerate bun.lock lockfile