### PR TITLE
ci: version up GitHub Actions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -35,7 +35,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: 💬 Add a comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
 
     steps:
     - name: 🏷️ Labeling
-      uses: actions/labeler@v5
+      uses: actions/labeler@v6
       with:
         sync-labels: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: 🪄 Add a comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary by Sourcery

Upgrade GitHub Actions workflows to use the latest action versions

CI:
- Upgrade actions/github-script from v7 to v8 in comment and preview workflows
- Upgrade actions/labeler from v5 to v6 in labeler workflow