### PR TITLE
build: version up dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.19.0-rc1-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.19.0-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "babel-plugin-react-compiler": "experimental",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.13",
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -121,25 +121,25 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@next/env": ["@next/env@15.6.0-canary.35", "", {}, "sha512-wmTXqxmZYtylFNZnrA/3BdEUATIKhc2egpfue384anIv67qYrYcIYI1gHCQIjc7QzGG/XEqnTHprq5YUg5JE8Q=="],
+    "@next/env": ["@next/env@15.6.0-canary.38", "", {}, "sha512-ALrtDNK1Es25oXyeAaF/9HzBec0yMWONw8uC8uSKX+EBzCoDHxXK7NgEidXwU5yT4bC36RHYn9QvgW1eR87jLw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.6.0-canary.35", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mZ1l8zhevvuwXclaPFyGocoN3szZVxVg3YWXoRZbwPOvTFS/KYi2hloVVwdn7CHD58FTpR3fBM5UDZQre4Ddsg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.6.0-canary.38", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+dOM2nYxaZmjES7cOBtEUVXtL3pZ7+3T8r8XWP3xf70c89pY4Whv5LFlVwyEzQ1VYw8g7kiZBFnfOUb23SOnCg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.6.0-canary.35", "", { "os": "darwin", "cpu": "x64" }, "sha512-+BD42XmhKKs5WGz7k4hH3+7m2yuLW3Eibq+1jHIURdhMYYfF4hCHvz+bbEzePA26n7qqWcPzcduPNuQM/kHEsQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.6.0-canary.38", "", { "os": "darwin", "cpu": "x64" }, "sha512-y+6+aWSH8qaKQqTHakkSCPVsyfgcAhfkE4CCkiUtuFQRiUYPv7zoWB7PV12P7inMEA/iqPQKcvXcV0ZsEqpyYA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.6.0-canary.35", "", { "os": "linux", "cpu": "arm64" }, "sha512-2ipvQawhEivPcuZ5tZHdenUYmg47sVp5KHgAB2kW8+2aQYJM5YNLC6mDeUsPfcjjRZ8iOG1aSHWAPMcjsbYdFg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.6.0-canary.38", "", { "os": "linux", "cpu": "arm64" }, "sha512-aubkPKfx849lojZpjgT9dsp9zBih43nVtI5SIIH22bwtmD+9GDN1CavIVWLDzUQkJacWC9+qM7Ap8LRKcjocKQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.6.0-canary.35", "", { "os": "linux", "cpu": "arm64" }, "sha512-80KadupuyGElWU7wKUTmz7gTFG5DYWHbF75BEy51xm2XG3l+xd6XyUcQtadWIAl7lP0mzgjiprQBbORfy/v3SQ=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.6.0-canary.38", "", { "os": "linux", "cpu": "arm64" }, "sha512-x6FZMSRTWN+P86k4gu0GeMPMqKDuod35WKpkgW0Rdshr14LBba3NgSF6TQgaQnkOpCHEr4iy3MNTc85clePA5w=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.6.0-canary.35", "", { "os": "linux", "cpu": "x64" }, "sha512-IFI6EG2NH0T9vuXvJoQ6YysmVTooEPRGf76gX54FZbj7pp+82yjGeZcNwgR/aWLi5kcpobg589EW0iUay0FMJQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.6.0-canary.38", "", { "os": "linux", "cpu": "x64" }, "sha512-dcE7X0EePLjPGvwA0McC9pqhlPvxXXTtUHdZ6CRcR6jkVPvw8teIIKgO5yK6wI0Jr3KYwcTLTs5QNl200rU5DA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.6.0-canary.35", "", { "os": "linux", "cpu": "x64" }, "sha512-uRTzSogXfcZ53TDybxahPOPq5zq0687zvzSee3CI9wparyAyIPzsOP1I7g/cAtQvtRrdsXSr+A596vmY8bbFbA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.6.0-canary.38", "", { "os": "linux", "cpu": "x64" }, "sha512-cisQ3Fh0fGOVssJnbpiCr7PpqFDW4v6HA7U330ovLYgVX2qjY/Tp6aiyTFGNnVLqUgNi4mn+9hhL4aXlQdyzIQ=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.6.0-canary.35", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYh2vTPKWbalN1LaaaF1QYcRk5R6SppLRoBQ8UoSp4ctYaQb4LBEFXX+Rl0uRNsmgFyxJ1uJJUGyvLDwh1MWrQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.6.0-canary.38", "", { "os": "win32", "cpu": "arm64" }, "sha512-rpH+iRhizp/LRFQkebGIowoJGOkbbMikdIrmN3VHOnSZ0ehzjYqbeXG7miOysjs9jOyZZxGMJI8r/Nf500YIig=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.6.0-canary.35", "", { "os": "win32", "cpu": "x64" }, "sha512-lMnzjhg+jkPLJP2qS1G+q0GTsjb0ZLeAWkSTlhyr4Dr944ZT7oaqR2VdHTQ1L6N2vDUv9jAgTuEaTkgX8MRVGA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.6.0-canary.38", "", { "os": "win32", "cpu": "x64" }, "sha512-SllJC94lsAnu10UT05GhSfrJpgjIfmuVnEYuvW5JwGUamHg3WhD6STPdOBB8UlG/OwJ702M+QZ/hfn7kJjMeCA=="],
 
-    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-09-30", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-09-30" }, "bin": { "playwright": "cli.js" } }, "sha512-EAGqeiin8pKfIQlQl4vh8izfijiUM5AFI504IQAiKz9GDwmvM/iDLlwWEtuzDklCrwSSyQQxOx74w97pMXZG/w=="],
+    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-10-01", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-10-01" }, "bin": { "playwright": "cli.js" } }, "sha512-1Sq2gaxXdrbx1fp5lHhOK6HHT29Iov5AjH7h2Mn223QPDpZ+7o9Jr1lz5An3R4tqAuKZkf543fFfaR6wjD0Osw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -195,7 +195,7 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4f1b470-20250929", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-BIKlxsVNi9lAGFV1UOR6tQsJi3yEB8VbWWiVSm7liwSRIawoih2/139J5YUh23ZPwtstXmWZGcxRCrBAHFlmJg=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-a44d7ea-20250930", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-w5O4bV2zNp/b4vLUelJZlNCzAFKVJ6YrgD/o4uisVz6eULBZO+Y043IzNSgCprgRyCFMCsDmfPPb4X0CuoR36A=="],
 
     "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
 
@@ -259,13 +259,13 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.6.0-canary.35", "", { "dependencies": { "@next/env": "15.6.0-canary.35", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.6.0-canary.35", "@next/swc-darwin-x64": "15.6.0-canary.35", "@next/swc-linux-arm64-gnu": "15.6.0-canary.35", "@next/swc-linux-arm64-musl": "15.6.0-canary.35", "@next/swc-linux-x64-gnu": "15.6.0-canary.35", "@next/swc-linux-x64-musl": "15.6.0-canary.35", "@next/swc-win32-arm64-msvc": "15.6.0-canary.35", "@next/swc-win32-x64-msvc": "15.6.0-canary.35", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-ZWYLPBXvHwo7VrGp/oEvzKY5Y7Qr9bJ8eHz0c/M9ftuB+WJgLAlpSjxKAj09PeUpXIH0Av+nemDRgSX8qa8qpw=="],
+    "next": ["next@15.6.0-canary.38", "", { "dependencies": { "@next/env": "15.6.0-canary.38", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.6.0-canary.38", "@next/swc-darwin-x64": "15.6.0-canary.38", "@next/swc-linux-arm64-gnu": "15.6.0-canary.38", "@next/swc-linux-arm64-musl": "15.6.0-canary.38", "@next/swc-linux-x64-gnu": "15.6.0-canary.38", "@next/swc-linux-x64-musl": "15.6.0-canary.38", "@next/swc-win32-arm64-msvc": "15.6.0-canary.38", "@next/swc-win32-x64-msvc": "15.6.0-canary.38", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-6PeNSEeWSolqoZVYWBv7BHsG7jDuB762mEytlAu/UyZP4bL7DK/YiqlzjHA6ylHodbtG7U39Pi0yx6nUwQh+hg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.56.0-alpha-2025-09-30", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-09-30" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/Xk35v4KiJOaPbQQegYl7K9lj1wvg/Zy0FzayHfaeT0GVPHoCssaHFDd1k2uU4oG+5P43dghKdGXBrgVy9m3Og=="],
+    "playwright": ["playwright@1.56.0-alpha-2025-10-01", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-10-01" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-fB26N0+NZyITpUIKBlJjA3CoFqBfNlhns/6urmK50nY6DgaHptCfKSJJLDhd37nsjQJ1ysV4n6WXSL8ifaEK6g=="],
 
-    "playwright-core": ["playwright-core@1.56.0-alpha-2025-09-30", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-ZZCkH/WVxnX6vQEwJr3UZVJxw5bksewBnYBGWCOSHU4CjbMIN0i+BwIXS25WmwA7J6Mk6iYORwfGndGQd7tddQ=="],
+    "playwright-core": ["playwright-core@1.56.0-alpha-2025-10-01", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-/n6Wa2cksUAj+thJhZpR1PvnK0E3WHhNBMTxr1G6XgdhhvUdX7y4Y6aU9FaJPa5S0P8tcX3jyBXLCYIv/pYlJA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -295,7 +295,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,10 +5,10 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     isrFlushToDisk: false,
     ppr: true,
-    reactCompiler: true,
     viewTransition: true,
   },
   output: "standalone",
+  reactCompiler: true,
   typedRoutes: true,
 }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@jambalaya56562/blog",
   "version": "0.8.0",
   "private": true,
+  "type": "module",
   "description": "JamBalaya56562's blog built with Next.js",
   "keywords": [
     "biome",
@@ -55,7 +56,7 @@
     "babel-plugin-react-compiler": "experimental",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.3"
   },
   "trustedDependencies": [
     "sharp"


### PR DESCRIPTION
## Summary by Sourcery

Enable ESM support by setting package.json to module type, bump TypeScript and Dockerfile syntax versions, and adjust Next.js configuration for the reactCompiler flag.

Enhancements:
- Relocate reactCompiler flag to the top-level in Next.js configuration

Build:
- Add "type": "module" to package.json to enable ESM support
- Bump typescript dependency to ^5.9.3
- Regenerate bun.lock to reflect updated dependencies

Deployment:
- Update Dockerfile syntax directive to dockerfile-upstream:1.19.0-labs