### PR TITLE
build: use custom start up script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0 /lambda-adapter /opt
 COPY --from=builder /usr/src/app/public ./public
 COPY --from=builder /usr/src/app/.next/standalone ./
 COPY --from=builder /usr/src/app/.next/static ./.next/static
+COPY --from=builder /usr/src/app/start.js ./start.js
 
 EXPOSE 3000
 ARG CONTENT_SOURCE=github
@@ -31,4 +32,4 @@ ARG GITHUB_REPO=blog
 ARG GITHUB_BRANCH=main
 ARG GITHUB_CONTENT_PATH=content
 ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000 CONTENT_SOURCE=${CONTENT_SOURCE} GITHUB_OWNER=${GITHUB_OWNER} GITHUB_REPO=${GITHUB_REPO} GITHUB_BRANCH=${GITHUB_BRANCH} GITHUB_CONTENT_PATH=${GITHUB_CONTENT_PATH}
-ENTRYPOINT ["/nodejs/bin/node", "server.js"]
+ENTRYPOINT ["/nodejs/bin/node", "start.js"]

--- a/start.js
+++ b/start.js
@@ -1,0 +1,17 @@
+const { mkdirSync, symlinkSync } = require("node:fs")
+
+// Create /tmp/cache and symlink .next/cache to it.
+// Lambda containers have a read-only filesystem except for /tmp.
+// Next.js image optimization writes to .next/cache/images/, so without
+// this symlink, optimized images fail to load on the first request.
+mkdirSync("/tmp/cache", { recursive: true })
+try {
+  symlinkSync("/tmp/cache", ".next/cache")
+} catch (e) {
+  // Symlink may already exist on warm Lambda container reuse
+  if (e.code !== "EEXIST") {
+    throw e
+  }
+}
+
+require("./server.js")


### PR DESCRIPTION
## Summary by Sourcery

Use a custom Node.js startup script to prepare Lambda filesystem state before launching the Next.js server.

Enhancements:
- Add a startup script that creates a writable cache directory and symlink for Next.js image optimization in the Lambda environment.
- Update the Dockerfile entrypoint to invoke the new startup script instead of calling the server directly.