### PR TITLE
fix: apply view transition api correctly

### DIFF
--- a/app/[locale]/blog/[slug]/page.tsx
+++ b/app/[locale]/blog/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import { MDXRemote } from "next-mdx-remote-client/rsc"
-import { cache } from "react"
+import { cache, ViewTransition } from "react"
 import remarkGfm from "remark-gfm"
 import {
   DEFAULT_THUMBNAIL,
@@ -108,23 +108,20 @@ export default async function BlogPostPage({
       <TableOfContents items={tocItems} title={dictionary.blog.toc} />
       <article>
         <header className="mb-8">
-          <h1
-            className="text-4xl font-bold"
-            style={{ viewTransitionName: `post-title-${slug}` }}
-          >
-            {post.frontmatter.title}
-          </h1>
-          <div
-            className="mt-2 flex items-center justify-between text-gray-500 dark:text-gray-400"
-            style={{ viewTransitionName: `post-meta-${slug}` }}
-          >
-            <span>
-              {dictionary.blog.postedOn} {post.frontmatter.date}
-            </span>
-            <ViewCounter slug={slug} count={viewCount} />
-            <span>·</span>
-            <span>{estimateReadingTime(post.content)} min read</span>
-          </div>
+          <ViewTransition name={`post-title-${slug}`} share="morph">
+            <h1 className="text-4xl font-bold">{post.frontmatter.title}</h1>
+          </ViewTransition>
+          <ViewTransition name={`post-meta-${slug}`} share="morph">
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 text-gray-500 dark:text-gray-400">
+              <span className="basis-full md:basis-auto">
+                {dictionary.blog.postedOn} {post.frontmatter.date}
+              </span>
+              <span className="hidden md:inline">·</span>
+              <ViewCounter slug={slug} count={viewCount} />
+              <span>·</span>
+              <span>{estimateReadingTime(post.content)} min read</span>
+            </div>
+          </ViewTransition>
           <div className="mt-2 flex gap-2">
             {post.frontmatter.tags.map((tag) => (
               <Link
@@ -148,16 +145,17 @@ export default async function BlogPostPage({
             </p>
           )}
         </header>
-        <div className="mb-12 overflow-hidden rounded-xl aspect-[21/9]">
-          <Image
-            src={post.frontmatter.image ?? DEFAULT_THUMBNAIL}
-            alt={post.frontmatter.title}
-            width={1200}
-            height={514}
-            className="h-full w-full object-cover"
-            style={{ viewTransitionName: `post-image-${slug}` }}
-          />
-        </div>
+        <ViewTransition name={`post-image-${slug}`} share="morph">
+          <div className="mb-12 overflow-hidden rounded-xl aspect-[21/9]">
+            <Image
+              src={post.frontmatter.image ?? DEFAULT_THUMBNAIL}
+              alt={post.frontmatter.title}
+              width={1200}
+              height={514}
+              className="h-full w-full object-cover"
+            />
+          </div>
+        </ViewTransition>
         <div className="prose dark:prose-invert max-w-none">
           <MDXRemote
             source={post.content}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -5,6 +5,7 @@ import { HeroSection } from "@/components/home/hero-section"
 import { ParticleNetwork } from "@/components/home/particle-network"
 import { RecentDispatches } from "@/components/home/recent-dispatches"
 import { createContentLoader } from "@/lib/content/loader"
+import { getViewCounts } from "@/lib/db/queries"
 import { isValidLocale } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/get-dictionary"
 
@@ -25,6 +26,7 @@ export default async function HomePage({
 
   const bentoGridPosts = posts.slice(0, 3)
   const recentPosts = posts.slice(3, 8)
+  const viewCounts = await getViewCounts(bentoGridPosts.map((p) => p.slug))
 
   return (
     <div className="relative">
@@ -32,7 +34,11 @@ export default async function HomePage({
       <CodeRain />
       <HeroSection locale={locale} dictionary={dictionary} />
       <div className="py-20">
-        <BentoGrid locale={locale} posts={bentoGridPosts} />
+        <BentoGrid
+          locale={locale}
+          posts={bentoGridPosts}
+          viewCounts={viewCounts}
+        />
       </div>
       <RecentDispatches
         locale={locale}

--- a/app/globals.css
+++ b/app/globals.css
@@ -324,17 +324,83 @@ body {
 }
 
 /* ===== View Transitions ===== */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-from-right {
+  from {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-to-left {
+  to {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-from-left {
+  from {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-to-right {
+  to {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
+
+/* Forward navigation */
+::view-transition-old(.nav-forward) {
+  animation:
+    90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+}
+
+::view-transition-new(.nav-forward) {
+  animation:
+    210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+}
+
+/* Back navigation */
+::view-transition-old(.nav-back) {
+  animation:
+    90ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-right;
+}
+
+::view-transition-new(.nav-back) {
+  animation:
+    210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    300ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-left;
+}
+
+/* Default cross-fade */
 ::view-transition-old(root) {
-  animation-duration: 200ms;
-  animation-timing-function: ease-in;
+  animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out;
 }
 
 ::view-transition-new(root) {
-  animation-duration: 300ms;
-  animation-timing-function: ease-out;
+  animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in;
 }
 
+/* Shared element morph timing */
 ::view-transition-group(*) {
-  animation-duration: 350ms;
+  animation-duration: 300ms;
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,2 @@
 [test]
-preload = ["./happydom.ts", "./test/unit/setup-lucide-mock.ts", "./test/unit/setup-next-navigation-mock.ts"]
+preload = ["./happydom.ts", "./test/unit/setup-react-mock.ts", "./test/unit/setup-lucide-mock.ts", "./test/unit/setup-next-navigation-mock.ts"]

--- a/components/article-card.tsx
+++ b/components/article-card.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image"
 import Link from "next/link"
+import { ViewTransition } from "react"
 import { TagLink } from "@/components/home/tag-link"
 import type { Post } from "@/lib/content/types"
 import type { Locale } from "@/lib/i18n/config"
@@ -36,21 +37,23 @@ export function ArticleCard({
       className={`card-title-hover group relative block overflow-hidden rounded-2xl bg-surface-container-lowest transition-colors ${isLarge ? "md:col-span-2" : ""}`}
     >
       <div className="absolute inset-y-0 left-0 w-1 rounded-l-2xl bg-primary-fixed opacity-0 transition-opacity group-hover:opacity-100" />
-      <Image
-        src={post.frontmatter.image ?? DEFAULT_THUMBNAIL}
-        alt={post.frontmatter.title}
-        width={800}
-        height={400}
-        className={`w-full object-cover aspect-video rounded-xl transition-opacity hover:opacity-90 ${isLarge ? "md:max-h-56" : "md:max-h-40"}`}
-        style={{ viewTransitionName: `post-image-${post.slug}` }}
-      />
+      <ViewTransition name={`post-image-${post.slug}`} share="morph">
+        <Image
+          src={post.frontmatter.image ?? DEFAULT_THUMBNAIL}
+          alt={post.frontmatter.title}
+          width={800}
+          height={400}
+          className={`w-full object-cover aspect-video rounded-xl transition-opacity hover:opacity-90 ${isLarge ? "md:max-h-56" : "md:max-h-40"}`}
+        />
+      </ViewTransition>
       <div className="p-4">
-        <h3
-          className={`card-title font-headline font-bold leading-tight text-on-surface transition-colors text-lg ${isLarge ? "md:text-2xl" : ""}`}
-          style={{ viewTransitionName: `post-title-${post.slug}` }}
-        >
-          {post.frontmatter.title}
-        </h3>
+        <ViewTransition name={`post-title-${post.slug}`} share="morph">
+          <h3
+            className={`card-title font-headline font-bold leading-tight text-on-surface transition-colors text-lg ${isLarge ? "md:text-2xl" : ""}`}
+          >
+            {post.frontmatter.title}
+          </h3>
+        </ViewTransition>
         {post.frontmatter.description && (
           <p className="mt-1 text-sm text-on-surface-variant line-clamp-2">
             {post.frontmatter.description}
@@ -68,20 +71,17 @@ export function ArticleCard({
             ))}
           </div>
         )}
-        <div
-          className="mt-2 flex items-center gap-3 text-xs text-on-surface-variant"
-          style={{ viewTransitionName: `post-meta-${post.slug}` }}
-        >
-          <span>{post.frontmatter.date}</span>
-          <span>·</span>
-          <span>{readMin} min read</span>
-          {viewCount != null && (
-            <>
-              <span>·</span>
-              <span>{viewCount.toLocaleString()} views</span>
-            </>
-          )}
-        </div>
+        <ViewTransition name={`post-meta-${post.slug}`} share="morph">
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 text-xs text-on-surface-variant">
+            <span className="basis-full md:basis-auto">
+              {post.frontmatter.date}
+            </span>
+            <span className="hidden md:inline">·</span>
+            <span>{readMin} min read</span>
+            <span>·</span>
+            <span>{(viewCount ?? 0).toLocaleString()} views</span>
+          </div>
+        </ViewTransition>
       </div>
     </Link>
   )

--- a/components/home/bento-grid.tsx
+++ b/components/home/bento-grid.tsx
@@ -5,9 +5,14 @@ import type { Locale } from "@/lib/i18n/config"
 interface BentoGridProps {
   readonly locale: Locale
   readonly posts: Post[]
+  readonly viewCounts?: Map<string, number>
 }
 
-export function BentoGrid({ locale, posts }: Readonly<BentoGridProps>) {
+export function BentoGrid({
+  locale,
+  posts,
+  viewCounts,
+}: Readonly<BentoGridProps>) {
   if (posts.length === 0) {
     return null
   }
@@ -25,13 +30,19 @@ export function BentoGrid({ locale, posts }: Readonly<BentoGridProps>) {
   return (
     <section className="mx-auto max-w-5xl px-4">
       <div className={`grid gap-4 ${gridCols}`}>
-        <ArticleCard post={first} locale={locale} isLarge />
+        <ArticleCard
+          post={first}
+          locale={locale}
+          isLarge
+          viewCount={viewCounts?.get(first.slug)}
+        />
         {rest.map((post) => (
           <ArticleCard
             key={post.slug}
             post={post}
             locale={locale}
             isLarge={false}
+            viewCount={viewCounts?.get(post.slug)}
           />
         ))}
       </div>

--- a/components/home/recent-dispatches.tsx
+++ b/components/home/recent-dispatches.tsx
@@ -1,5 +1,6 @@
 import type { Route } from "next"
 import Link from "next/link"
+import { ViewTransition } from "react"
 import { TagLink } from "@/components/home/tag-link"
 import type { Post } from "@/lib/content/types"
 import type { Locale } from "@/lib/i18n/config"
@@ -74,12 +75,14 @@ export function RecentDispatches({
                   {number}
                 </span>
                 <div>
-                  <h3
-                    className="card-title font-headline text-xl font-bold text-primary transition-colors dark:text-white"
-                    style={{ viewTransitionName: `post-title-${post.slug}` }}
+                  <ViewTransition
+                    name={`post-title-${post.slug}`}
+                    share="morph"
                   >
-                    {post.frontmatter.title}
-                  </h3>
+                    <h3 className="card-title font-headline text-xl font-bold text-primary transition-colors dark:text-white">
+                      {post.frontmatter.title}
+                    </h3>
+                  </ViewTransition>
                   <div className="mt-1 flex gap-4">
                     <span className="text-xs font-medium text-secondary">
                       {post.frontmatter.date}

--- a/test/unit/components/article-card.test.tsx
+++ b/test/unit/components/article-card.test.tsx
@@ -101,9 +101,9 @@ describe("ArticleCard rendering", () => {
     expect(container.textContent).toContain("views")
   })
 
-  test("viewCount is not displayed when omitted", () => {
+  test("viewCount defaults to 0 views when omitted", () => {
     const { container } = render(<ArticleCard post={basePost} locale="en" />)
-    expect(container.textContent).not.toContain("views")
+    expect(container.textContent).toContain("0 views")
   })
 
   test("viewCount of zero is displayed", () => {

--- a/test/unit/components/home/bento-grid.test.tsx
+++ b/test/unit/components/home/bento-grid.test.tsx
@@ -123,6 +123,45 @@ describe("BentoGrid", () => {
     expect(grid?.className).toContain("md:grid-cols-2")
   })
 
+  test("passes viewCounts to ArticleCard by slug", () => {
+    const posts = [
+      createMockPost({ slug: "post-a" }),
+      createMockPost({ slug: "post-b" }),
+    ]
+    const viewCounts = new Map([
+      ["post-a", 123],
+      ["post-b", 456],
+    ])
+    const { container } = render(
+      <BentoGrid locale="en" posts={posts} viewCounts={viewCounts} />,
+    )
+    expect(container.textContent).toContain("123 views")
+    expect(container.textContent).toContain("456 views")
+  })
+
+  test("falls back to 0 views when viewCounts is omitted", () => {
+    const posts = [
+      createMockPost({ slug: "post-a" }),
+      createMockPost({ slug: "post-b" }),
+    ]
+    const { container } = render(<BentoGrid locale="en" posts={posts} />)
+    const matches = container.textContent?.match(/0 views/g)
+    expect(matches).toHaveLength(2)
+  })
+
+  test("uses viewCounts when present and 0 views as fallback when missing", () => {
+    const posts = [
+      createMockPost({ slug: "post-a" }),
+      createMockPost({ slug: "post-b" }),
+    ]
+    const viewCounts = new Map([["post-a", 99]])
+    const { container } = render(
+      <BentoGrid locale="en" posts={posts} viewCounts={viewCounts} />,
+    )
+    expect(container.textContent).toContain("99 views")
+    expect(container.textContent).toContain("0 views")
+  })
+
   test("each card links to correct blog post path", () => {
     const posts = [
       createMockPost({

--- a/test/unit/setup-react-mock.ts
+++ b/test/unit/setup-react-mock.ts
@@ -1,0 +1,18 @@
+import { mock } from "bun:test"
+
+// Preload mock for react to add ViewTransition which is not yet exported
+// from the CJS entry point that Bun resolves in test environment.
+// Instead of replacing the entire module (which breaks react-dom internals),
+// we patch the ViewTransition export onto the existing react module.
+const React = require("react")
+if (!React.ViewTransition) {
+  React.ViewTransition = ({
+    children,
+  }: {
+    name?: string
+    share?: string
+    children: unknown
+  }) => children
+}
+
+mock.module("react", () => React)


### PR DESCRIPTION
## Summary by Sourcery

Implement proper use of the View Transition API for blog-related navigation and refine blog card metadata behavior.

New Features:
- Introduce directional view transition animations for forward and back navigation using fade and slide effects.
- Add React ViewTransition wrappers around shared blog elements to enable morphing transitions between list and detail views.

Bug Fixes:
- Ensure blog article view counts are always displayed, defaulting to 0 when no count is provided.
- Load view counts for featured home page posts and pass them into the bento grid article cards.

Enhancements:
- Adjust view transition root and shared-element timing for smoother cross-fade and morph animations.
- Improve blog card and post header layout responsiveness by allowing metadata to wrap on small screens.

Build:
- Extend Bun test configuration to preload a React mock that exposes the ViewTransition component.

Tests:
- Update ArticleCard unit tests to assert the new default '0 views' behavior and support ViewTransition via a React mock preload.