### PR TITLE
feat: add text search on article list

### DIFF
--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -4,9 +4,13 @@ import { notFound } from "next/navigation"
 import { Suspense } from "react"
 import { ArticleCard } from "@/components/article-card"
 import { Pagination } from "@/components/pagination"
+import { SearchInput } from "@/components/search-input"
 import { BlogListSkeleton } from "@/components/skeletons"
 import { createContentLoader } from "@/lib/content/loader"
-import { filterPostsByTag } from "@/lib/content/sort-filter"
+import {
+  filterPostsByKeyword,
+  filterPostsByTag,
+} from "@/lib/content/sort-filter"
 import { getViewCounts } from "@/lib/db/queries"
 import type { Locale } from "@/lib/i18n/config"
 import { isValidLocale } from "@/lib/i18n/config"
@@ -18,15 +22,18 @@ async function BlogListContent({
   searchParams,
 }: {
   locale: Locale
-  searchParams: Promise<{ tag?: string; page?: string }>
+  searchParams: Promise<{ tag?: string; page?: string; q?: string }>
 }) {
-  const { tag, page: pageParam } = await searchParams
+  const { tag, page: pageParam, q } = await searchParams
   const dictionary = getDictionary(locale)
   const loader = createContentLoader()
   let posts = await loader.getAllPosts(locale)
 
   if (tag) {
     posts = filterPostsByTag(posts, tag)
+  }
+  if (q) {
+    posts = filterPostsByKeyword(posts, q)
   }
 
   const page = Math.max(1, Number(pageParam) || 1)
@@ -42,11 +49,39 @@ async function BlogListContent({
   if (tag) {
     paginationSearchParams.tag = tag
   }
+  if (q) {
+    paginationSearchParams.q = q
+  }
 
   return (
     <div>
       <h1 className="mb-6 text-3xl font-bold">{dictionary.blog.title}</h1>
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4">
+        <Suspense>
+          <SearchInput
+            placeholder={dictionary.blog.searchPlaceholder}
+            label={dictionary.blog.searchLabel}
+            basePath={`/${locale}/blog`}
+          />
+        </Suspense>
+      </div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        {q && (
+          <>
+            <span>{dictionary.blog.searchResultsFor}</span>
+            <span className="rounded bg-green-100 px-2 py-1 text-sm font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
+              {q}
+            </span>
+            <Link
+              href={
+                `/${locale}/blog${tag ? `?tag=${encodeURIComponent(tag)}` : ""}` as Route
+              }
+              className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {dictionary.blog.clearSearch}
+            </Link>
+          </>
+        )}
         {tag ? (
           <>
             <span>{dictionary.blog.filterByTag}</span>
@@ -54,19 +89,23 @@ async function BlogListContent({
               {tag}
             </span>
             <Link
-              href={`/${locale}/blog` as Route}
+              href={
+                `/${locale}/blog${q ? `?q=${encodeURIComponent(q)}` : ""}` as Route
+              }
               className="text-sm text-blue-600 hover:underline dark:text-blue-400"
             >
               {dictionary.blog.clearFilter}
             </Link>
           </>
         ) : (
-          <>
-            <span>{dictionary.blog.filterByTag}</span>
-            <span className="text-sm text-on-surface-variant">
-              {dictionary.blog.noActiveFilter}
-            </span>
-          </>
+          !q && (
+            <>
+              <span>{dictionary.blog.filterByTag}</span>
+              <span className="text-sm text-on-surface-variant">
+                {dictionary.blog.noActiveFilter}
+              </span>
+            </>
+          )
         )}
       </div>
       {posts.length === 0 ? (
@@ -107,7 +146,7 @@ export default async function BlogListPage({
   searchParams,
 }: {
   params: Promise<{ locale: string }>
-  searchParams: Promise<{ tag?: string; page?: string }>
+  searchParams: Promise<{ tag?: string; page?: string; q?: string }>
 }) {
   const { locale } = await params
   if (!isValidLocale(locale)) {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,3 @@
 [test]
+root = "./test/unit"
 preload = ["./happydom.ts", "./test/unit/setup-react-mock.ts", "./test/unit/setup-lucide-mock.ts", "./test/unit/setup-next-navigation-mock.ts"]

--- a/components/search-input.tsx
+++ b/components/search-input.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import type { Route } from "next"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useEffect, useId, useRef, useState } from "react"
+
+interface SearchInputProps {
+  readonly placeholder: string
+  readonly label: string
+  readonly basePath: string
+}
+
+export function SearchInput({
+  placeholder,
+  label,
+  basePath,
+}: SearchInputProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [value, setValue] = useState(searchParams.get("q") ?? "")
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    setValue(searchParams.get("q") ?? "")
+  }, [searchParams])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = e.target.value
+    setValue(newValue)
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+    timerRef.current = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (newValue.trim()) {
+        params.set("q", newValue.trim())
+      } else {
+        params.delete("q")
+      }
+      params.delete("page")
+      const qs = params.toString()
+      const href = qs ? `${basePath}?${qs}` : basePath
+      router.push(href as Route)
+    }, 300)
+  }
+
+  const id = useId()
+
+  return (
+    <div className="relative">
+      <label htmlFor={id} className="sr-only">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="search"
+        value={value}
+        onChange={handleChange}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-2.5 text-sm text-on-surface placeholder:text-on-surface-variant transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+      />
+    </div>
+  )
+}

--- a/lib/content/sort-filter.ts
+++ b/lib/content/sort-filter.ts
@@ -9,3 +9,20 @@ export function sortPostsByDate(posts: Post[]): Post[] {
 export function filterPostsByTag(posts: Post[], tag: string): Post[] {
   return posts.filter((p) => p.frontmatter.tags.includes(tag))
 }
+
+export function filterPostsByKeyword(posts: Post[], keyword: string): Post[] {
+  const trimmed = keyword.trim()
+  if (!trimmed) {
+    return posts
+  }
+  const normalized = trimmed.toLowerCase()
+  return posts.filter((post) => {
+    const { title, description, tags } = post.frontmatter
+    return (
+      title.toLowerCase().includes(normalized) ||
+      description.toLowerCase().includes(normalized) ||
+      post.content.toLowerCase().includes(normalized) ||
+      tags.some((tag) => tag.toLowerCase().includes(normalized))
+    )
+  })
+}

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -47,7 +47,11 @@
     "continueExploring": "Continue Exploring",
     "previousPage": "Previous",
     "nextPage": "Next",
-    "pagination": "Pagination"
+    "pagination": "Pagination",
+    "searchPlaceholder": "Search articles...",
+    "searchLabel": "Search",
+    "searchResultsFor": "Search results for:",
+    "clearSearch": "Clear search"
   },
   "language": {
     "switchTo": "日本語",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -47,7 +47,11 @@
     "continueExploring": "他の記事を探す",
     "previousPage": "前へ",
     "nextPage": "次へ",
-    "pagination": "ページナビゲーション"
+    "pagination": "ページナビゲーション",
+    "searchPlaceholder": "記事を検索...",
+    "searchLabel": "検索",
+    "searchResultsFor": "検索結果:",
+    "clearSearch": "検索をクリア"
   },
   "language": {
     "switchTo": "English",

--- a/test/unit/content/sort-filter.test.ts
+++ b/test/unit/content/sort-filter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import fc from "fast-check"
-import { filterPostsByTag, sortPostsByDate } from "@/lib/content/sort-filter"
+import {
+  filterPostsByKeyword,
+  filterPostsByTag,
+  sortPostsByDate,
+} from "@/lib/content/sort-filter"
 import type { Post } from "@/lib/content/types"
 
 const dateArb = fc
@@ -64,6 +68,59 @@ describe("Sort and Filter", () => {
         },
       ),
       { numRuns: 100 },
+    )
+  })
+
+  test("Property: keyword filtering returns only matching posts", () => {
+    fc.assert(
+      fc.property(
+        fc.array(postArb, { minLength: 1, maxLength: 20 }),
+        (posts) => {
+          const keyword = posts[0].frontmatter.title.slice(0, 3).trim()
+          if (!keyword) {
+            return
+          }
+          const filtered = filterPostsByKeyword(posts, keyword)
+          const normalized = keyword.toLowerCase()
+          for (const post of filtered) {
+            const haystack = [
+              post.frontmatter.title,
+              post.frontmatter.description,
+              post.content,
+              ...post.frontmatter.tags,
+            ]
+              .join(" ")
+              .toLowerCase()
+            expect(haystack).toContain(normalized)
+          }
+        },
+      ),
+      { numRuns: 100 },
+    )
+  })
+
+  test("Property: keyword filtering is case-insensitive", () => {
+    fc.assert(
+      fc.property(postArb, (post) => {
+        const keyword = post.frontmatter.title
+        const upper = filterPostsByKeyword([post], keyword.toUpperCase())
+        const lower = filterPostsByKeyword([post], keyword.toLowerCase())
+        expect(upper.length).toBe(lower.length)
+      }),
+      { numRuns: 100 },
+    )
+  })
+
+  test("Property: empty keyword returns all posts", () => {
+    fc.assert(
+      fc.property(
+        fc.array(postArb, { minLength: 0, maxLength: 20 }),
+        (posts) => {
+          const filtered = filterPostsByKeyword(posts, "")
+          expect(filtered.length).toBe(posts.length)
+        },
+      ),
+      { numRuns: 50 },
     )
   })
 


### PR DESCRIPTION
## Summary by Sourcery

Add keyword-based text search to the blog article list and wire it through the UI, content filtering, and routing.

New Features:
- Introduce keyword search filtering for posts using a new filterPostsByKeyword helper that searches titles, descriptions, content, and tags.
- Add a searchable blog list UI with a debounced search input that syncs with the URL query parameter and supports combined tag and keyword filters.

Enhancements:
- Propagate the new search query parameter through blog list pagination and clear-filter links to preserve active search or tag state.
- Configure Bun test runner to use the unit test directory as the test root.

Tests:
- Add property-based tests to validate keyword filtering behavior, including match correctness, case-insensitivity, and empty-query handling.