### PR TITLE
feat: add sort feature

### DIFF
--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -6,12 +6,14 @@ import { ArticleCard } from "@/components/article-card"
 import { Pagination } from "@/components/pagination"
 import { SearchInput } from "@/components/search-input"
 import { BlogListSkeleton } from "@/components/skeletons"
+import { SortSelect } from "@/components/sort-select"
 import { createContentLoader } from "@/lib/content/loader"
 import {
   filterPostsByKeyword,
   filterPostsByTag,
+  sortPostsByViews,
 } from "@/lib/content/sort-filter"
-import { getViewCounts } from "@/lib/db/queries"
+import { getAllViewCounts, getViewCounts } from "@/lib/db/queries"
 import type { Locale } from "@/lib/i18n/config"
 import { isValidLocale } from "@/lib/i18n/config"
 import { getDictionary } from "@/lib/i18n/get-dictionary"
@@ -22,9 +24,14 @@ async function BlogListContent({
   searchParams,
 }: {
   locale: Locale
-  searchParams: Promise<{ tag?: string; page?: string; q?: string }>
+  searchParams: Promise<{
+    tag?: string
+    page?: string
+    q?: string
+    sort?: string
+  }>
 }) {
-  const { tag, page: pageParam, q } = await searchParams
+  const { tag, page: pageParam, q, sort } = await searchParams
   const dictionary = getDictionary(locale)
   const loader = createContentLoader()
   let posts = await loader.getAllPosts(locale)
@@ -34,6 +41,12 @@ async function BlogListContent({
   }
   if (q) {
     posts = filterPostsByKeyword(posts, q)
+  }
+
+  if (sort === "popular") {
+    const allViews = await getAllViewCounts()
+    const allViewsMap = new Map(allViews.map((v) => [v.slug, v.count]))
+    posts = sortPostsByViews(posts, allViewsMap)
   }
 
   const page = Math.max(1, Number(pageParam) || 1)
@@ -52,15 +65,30 @@ async function BlogListContent({
   if (q) {
     paginationSearchParams.q = q
   }
+  if (sort) {
+    paginationSearchParams.sort = sort
+  }
 
   return (
     <div>
       <h1 className="mb-6 text-3xl font-bold">{dictionary.blog.title}</h1>
-      <div className="mb-4">
+      <div className="mb-4 flex flex-col sm:flex-row gap-2">
+        <div className="flex-1">
+          <Suspense>
+            <SearchInput
+              placeholder={dictionary.blog.searchPlaceholder}
+              label={dictionary.blog.searchLabel}
+              basePath={`/${locale}/blog`}
+            />
+          </Suspense>
+        </div>
         <Suspense>
-          <SearchInput
-            placeholder={dictionary.blog.searchPlaceholder}
-            label={dictionary.blog.searchLabel}
+          <SortSelect
+            labels={{
+              sortLabel: dictionary.blog.sortLabel,
+              sortNewest: dictionary.blog.sortNewest,
+              sortPopular: dictionary.blog.sortPopular,
+            }}
             basePath={`/${locale}/blog`}
           />
         </Suspense>
@@ -146,7 +174,12 @@ export default async function BlogListPage({
   searchParams,
 }: {
   params: Promise<{ locale: string }>
-  searchParams: Promise<{ tag?: string; page?: string; q?: string }>
+  searchParams: Promise<{
+    tag?: string
+    page?: string
+    q?: string
+    sort?: string
+  }>
 }) {
   const { locale } = await params
   if (!isValidLocale(locale)) {

--- a/components/sort-select.tsx
+++ b/components/sort-select.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import type { Route } from "next"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useId } from "react"
+
+interface SortSelectProps {
+  readonly labels: {
+    sortLabel: string
+    sortNewest: string
+    sortPopular: string
+  }
+  readonly basePath: string
+}
+
+export function SortSelect({ labels, basePath }: SortSelectProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const id = useId()
+  const sortParam = searchParams.get("sort")
+  const current = sortParam === "popular" ? "popular" : "newest"
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (e.target.value === "popular") {
+      params.set("sort", "popular")
+    } else {
+      params.delete("sort")
+    }
+    params.delete("page")
+    const qs = params.toString()
+    const href = qs ? `${basePath}?${qs}` : basePath
+    router.push(href as Route)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor={id}
+        className="text-sm text-on-surface-variant whitespace-nowrap"
+      >
+        {labels.sortLabel}
+      </label>
+      <select
+        id={id}
+        value={current}
+        onChange={handleChange}
+        className="rounded-xl border border-outline-variant bg-surface-container-lowest px-3 py-2.5 text-sm text-on-surface transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+      >
+        <option value="newest">{labels.sortNewest}</option>
+        <option value="popular">{labels.sortPopular}</option>
+      </select>
+    </div>
+  )
+}

--- a/lib/content/sort-filter.ts
+++ b/lib/content/sort-filter.ts
@@ -10,6 +10,15 @@ export function filterPostsByTag(posts: Post[], tag: string): Post[] {
   return posts.filter((p) => p.frontmatter.tags.includes(tag))
 }
 
+export function sortPostsByViews(
+  posts: Post[],
+  viewCounts: Map<string, number>,
+): Post[] {
+  return [...posts].sort(
+    (a, b) => (viewCounts.get(b.slug) ?? 0) - (viewCounts.get(a.slug) ?? 0),
+  )
+}
+
 export function filterPostsByKeyword(posts: Post[], keyword: string): Post[] {
   const trimmed = keyword.trim()
   if (!trimmed) {

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -51,7 +51,10 @@
     "searchPlaceholder": "Search articles...",
     "searchLabel": "Search",
     "searchResultsFor": "Search results for:",
-    "clearSearch": "Clear search"
+    "clearSearch": "Clear search",
+    "sortLabel": "Sort by:",
+    "sortNewest": "Newest",
+    "sortPopular": "Most viewed"
   },
   "language": {
     "switchTo": "日本語",

--- a/lib/i18n/dictionaries/ja.json
+++ b/lib/i18n/dictionaries/ja.json
@@ -51,7 +51,10 @@
     "searchPlaceholder": "記事を検索...",
     "searchLabel": "検索",
     "searchResultsFor": "検索結果:",
-    "clearSearch": "検索をクリア"
+    "clearSearch": "検索をクリア",
+    "sortLabel": "並び替え:",
+    "sortNewest": "新しい順",
+    "sortPopular": "人気順"
   },
   "language": {
     "switchTo": "English",


### PR DESCRIPTION
## Summary by Sourcery

Add support for sorting blog posts by popularity via a new sort parameter and UI control.

New Features:
- Introduce a sort query parameter on the blog listing page to allow sorting posts by popularity.
- Add a SortSelect client component that lets users toggle between newest and popular blog post ordering.

Enhancements:
- Add a helper to sort blog posts by view counts and integrate it into the blog post listing flow when popular sorting is selected.
- Update blog list layout to accommodate both search and sort controls side by side.
- Extend i18n dictionaries to provide localized labels for the new sort options.