### PR TITLE
fix: restore production build under TypeScript 7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -202,25 +202,25 @@
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
-    "@next/env": ["@next/env@16.3.0-canary.84", "", {}, "sha512-3hlIQ6RdqC4xwzDqLsA0XVDeLzw08Vl4h6KMjfsG63QFF7/tzazGI9Bc/IE5UPDoUGrQ8a8FzhjZSyAX/559Xg=="],
+    "@next/env": ["@next/env@16.3.0-canary.85", "", {}, "sha512-uiuvNIrAoo1WkKtBtlrrXny1qVmUBy6HYy6VEldF3hbuI+fBRv+S+CotYFZu7KmAIFTw2BdSZT7Mm0LGIb2Hxg=="],
 
-    "@next/mdx": ["@next/mdx@16.3.0-canary.84", "", { "dependencies": { "source-map": "^0.7.0" }, "peerDependencies": { "@mdx-js/loader": ">=0.15.0", "@mdx-js/react": ">=0.15.0" }, "optionalPeers": ["@mdx-js/loader", "@mdx-js/react"] }, "sha512-PphnihxEm9y2bNno5cgzQATkiruAvD70cxZto7s10DX6hEW3nBMbEyvBuw707JeFHBAA0ObFrqprmcDsyYM+OQ=="],
+    "@next/mdx": ["@next/mdx@16.3.0-canary.85", "", { "dependencies": { "source-map": "^0.7.0" }, "peerDependencies": { "@mdx-js/loader": ">=0.15.0", "@mdx-js/react": ">=0.15.0" }, "optionalPeers": ["@mdx-js/loader", "@mdx-js/react"] }, "sha512-6LA/ECtE+dM/R44q6z5jDVYvZkEMld+ojxwetGxXcXWAQj5VqMvi0Ho/s8DYy2B4gVsK4J/CfwXY6NpJNzmpHQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.84", "", { "os": "darwin", "cpu": "arm64" }, "sha512-H0lxD+0tfvUUY3D66Djg8uXuQJnO+aheD8Vf3ZVgH3OiGJ6mjiGjz+ps6p0H3U6wQNWyUIT9V73cAvCdlvVkhQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.85", "", { "os": "darwin", "cpu": "arm64" }, "sha512-D1fn9ybJOQm/ux2u/mmXdZ5R5eP+v1Yhuvh74Mag+v7282ZrWsqxI7VV8AdNReUKmOdMziARKMEtIwKddxf9gg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.84", "", { "os": "darwin", "cpu": "x64" }, "sha512-2vj4yLD3QUQVUC7+uUjEVSaw0xcY1thTAuzUnrQFEJaqIGeD8TOrwvazCmCsrA+9I6F3m+DyTqBbmpZ8ZXxmgw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.85", "", { "os": "darwin", "cpu": "x64" }, "sha512-G/UODhcsyFvoUsdGPnQWdAkeWqJ8umPwQKJ8RgJRJSqQeMNx5xgY1eKeVwQ3zeM/3uYVv16z4BM7yyJNEf7z/A=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.84", "", { "os": "linux", "cpu": "arm64" }, "sha512-16vl4NmyK7kkwcXuK5MQsriV9liWCDkY1tVqdk6DtzdKLfHnNkhd0lCk+iGrPNilDdpgXojgmZBKZSh0PjH1zA=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.85", "", { "os": "linux", "cpu": "arm64" }, "sha512-0qDnn76ZvWSFGL01nVrJqJnwAbSWVb6Gvu4bvys1X5wO59ll+u6jxtgIxXtKyoPsn/FktMOmJWJDZgn9iMiQ6A=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.84", "", { "os": "linux", "cpu": "arm64" }, "sha512-uORyuQatCWBnHbw/ShjEbmhA06QbRzgTUUK2OY85Sn6Bu9eU0oQ9kqfcbqKOXe1UbX3gmWMhtjVWM0kxVglvyw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.85", "", { "os": "linux", "cpu": "arm64" }, "sha512-gG0D/ecZBkwm9KVaFMSS2atSGNnb5rq//ZAuNkJPZp4NHihx6BKcAVCKyInfcj+Ho1aTUhj2NjYX8cI5rK3AaQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.84", "", { "os": "linux", "cpu": "x64" }, "sha512-ajKwgFybqgSwGWsyHBd+4UUvl4fr9aWC9tmbtpAMVQsap9eR/9lLSg5yq8D6/yvSoTdUVGx8ZzVCE+l+kgB3IA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.85", "", { "os": "linux", "cpu": "x64" }, "sha512-Fxr7+calez7XAD31D65oLNKJ4EyVdMJYk8do3Sjxg0FqWEcm2A7zLii9syGU1zbfa3+oqBHyjU09+Or4RNp0HA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.84", "", { "os": "linux", "cpu": "x64" }, "sha512-uufJJ1Y2UAp9jvawctucYYV1mBJ4WHaXkTpWM3Mi6+EAk/L7DGKupxco1D0srW1a9o/e1xFdNSko9KM6lXFjmQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.85", "", { "os": "linux", "cpu": "x64" }, "sha512-jwkd7f83dome8KIRGXlgAPcpbb4nZcst4doOSuuiFklwNqA3r20gkgma6N00qk5CLaLZ3zNTPyC2HBdU5WApZw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.84", "", { "os": "win32", "cpu": "arm64" }, "sha512-ZRM6uVm440LRg1dFi9vVdmSCaGK/UQrmnjbupK+6aDHTRAi8zlnI4omGxN85dXX3STLLhUVlLiYN/U5DJipQbA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.85", "", { "os": "win32", "cpu": "arm64" }, "sha512-83506Up1rTPUBbxak9pI25NklVCN9dqxMe74nlHFbZIntl6934egSUxMsH5QJ5Qm2pMGvofQvS/rnTU6F6FD4Q=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.84", "", { "os": "win32", "cpu": "x64" }, "sha512-O9lxgvi17f4/nJzyRqpLlXHVUmXbpSVgUq64TIUyHDt3IuPDRy8q6+b2GP+BMqhXSkM0/a7kj4Ygvo2+qPWw+A=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.85", "", { "os": "win32", "cpu": "x64" }, "sha512-DHzls2XLEHkdZ4R9NgKVXcfMoQBBY2jy5nHJUFEyVRxmsj+3bSoJbsYYw3YTxeiLOa9IvjD5ghAP/oH7k2J+0w=="],
 
     "@playwright/mcp": ["@playwright/mcp@0.0.78", "", { "dependencies": { "playwright": "1.62.0-alpha-1783623505000", "playwright-core": "1.62.0-alpha-1783623505000" }, "bin": { "playwright-mcp": "cli.js" } }, "sha512-XLTUeA6mEN9sQ+hJ4dfG8EIkDbxS0K3Trc2RBkUJuf02TgE2FQRNTMtq/aJfhyRMINsRl/Ybc4sxcWLtFn4/TQ=="],
 
@@ -596,7 +596,7 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
-    "next": ["next@16.3.0-canary.84", "", { "dependencies": { "@next/env": "16.3.0-canary.84", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.84", "@next/swc-darwin-x64": "16.3.0-canary.84", "@next/swc-linux-arm64-gnu": "16.3.0-canary.84", "@next/swc-linux-arm64-musl": "16.3.0-canary.84", "@next/swc-linux-x64-gnu": "16.3.0-canary.84", "@next/swc-linux-x64-musl": "16.3.0-canary.84", "@next/swc-win32-arm64-msvc": "16.3.0-canary.84", "@next/swc-win32-x64-msvc": "16.3.0-canary.84", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-clM23cjcqn67r5NtVb3Wsv+ZhpWlOyVbBGR41tUczIxyQp/IbdeROjTk7PZYimHk2AoTkfOB/2CwTcV9s8HHKw=="],
+    "next": ["next@16.3.0-canary.85", "", { "dependencies": { "@next/env": "16.3.0-canary.85", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.85", "@next/swc-darwin-x64": "16.3.0-canary.85", "@next/swc-linux-arm64-gnu": "16.3.0-canary.85", "@next/swc-linux-arm64-musl": "16.3.0-canary.85", "@next/swc-linux-x64-gnu": "16.3.0-canary.85", "@next/swc-linux-x64-musl": "16.3.0-canary.85", "@next/swc-win32-arm64-msvc": "16.3.0-canary.85", "@next/swc-win32-x64-msvc": "16.3.0-canary.85", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-FwR/3LOtB8m5UwmG2Ty5uaEDVlhwYRR2PEImBoO2Ae5mOJOrJlfY0eOi8hvqItQz1wLlYn6193I8T352Y5whFg=="],
 
     "next-mdx-remote-client": ["next-mdx-remote-client@2.1.11", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@mdx-js/mdx": "^3.1.1", "@mdx-js/react": "^3.1.1", "@types/mdx": "^2.0.13", "remark-mdx-remove-esm": "^1.3.2", "serialize-error": "^13.0.1", "vfile": "^6.0.3", "vfile-matter": "^5.0.1" }, "peerDependencies": { "react": ">= 19.1.0", "react-dom": ">= 19.1.0" } }, "sha512-R28K170ODHCdzoqyoNosTSMGKEj/MEHknQELSjK6eQVsGXxeQ3brORmusql3AvPBqTGOfYVVeTvuIC/133UZxw=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     isrFlushToDisk: false,
     viewTransition: true,
+    useTypeScriptCli: true,
     serverActions: {
       allowedOrigins: ["kokohore56562wanwan.site"],
     },

--- a/test/unit/lib/db/queries.test.ts
+++ b/test/unit/lib/db/queries.test.ts
@@ -47,7 +47,7 @@ describe("incrementViewCount", () => {
 
   test("calls insert with upsert when db is available", async () => {
     const onConflictDoUpdateMock = mock(() => Promise.resolve())
-    const valuesMock = mock(() => ({
+    const valuesMock = mock((_values: { slug: string; count: number }) => ({
       onConflictDoUpdate: onConflictDoUpdateMock,
     }))
     const insertMock = mock(() => ({ values: valuesMock }))


### PR DESCRIPTION
Dependabot bumped `typescript` from ^6 to ^7 (#1074). TypeScript 7 is
the new native compiler, which does not expose the JS compiler API that
Next.js uses for its build-time type check, so `next build` failed at
the "Running TypeScript" step:

    TypeScript 7.0.2 does not provide the compiler API required by
    Next.js. Enable experimental.useTypeScriptCli ... or install
    TypeScript 6 instead.

Because the Playwright CI job runs `bun run build` before the tests,
every browser matrix entry failed at the build step before any test ran.

- Enable `experimental.useTypeScriptCli` so Next.js type-checks via the
  TypeScript CLI instead of the compiler API.
- Fix a latent type error the CLI check surfaced: `valuesMock` was
  declared with a zero-arg implementation, so Bun typed `mock.calls`
  entries as empty tuples and `calls[0][0]` failed (TS2493). Declare the
  mock's argument so the recorded-args tuple has an element.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Summary by Sourcery

Restore compatibility of the Next.js production build and tests with TypeScript 7 by switching to the TypeScript CLI type-checking path and addressing a surfaced typing issue.

Bug Fixes:
- Enable Next.js experimental.useTypeScriptCli to prevent build failures with TypeScript 7's lack of compiler API support.
- Correct a test mock's argument typing so recorded call tuples are inferred correctly and TypeScript type-checking passes under the CLI.

Tests:
- Adjust db query test mocks to align with stricter TypeScript 7 type inference and ensure the existing tests compile and run successfully.