### PR TITLE
fix(ci): build PR head commit in Docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPOSITORY: jambalaya56562/blog
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  CONTEXT: ${{ github.server_url }}/${{ github.repository }}.git#${{ github.sha }}
+  CONTEXT: ${{ github.server_url }}/${{ github.repository }}.git#${{ github.event.pull_request.head.sha || github.sha }}
   IS_PUSH: ${{ github.event_name == 'push' || inputs.push == true }}
 
 jobs:


### PR DESCRIPTION

On `pull_request_target`, `github.sha` resolves to the base branch tip,
not the PR. The Docker build context (`.git#<sha>`) therefore built
base-branch code and never tested the PR's actual changes — so a PR that
fixes a broken build still showed a red Docker check (and vice versa).

Use `github.event.pull_request.head.sha` (matching the existing `SHA`
env var) in the CONTEXT build context so PR changes are actually built.
On `push` the expression falls back to `github.sha` as before.

Note: this makes Docker CI build PR head code under pull_request_target,
which runs with repository secrets. The existing
`if: github.repository_owner == 'jambalaya56562'` guard limits runs to
this repo; revisit if fork PRs ever need to be built.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
