### PR TITLE
fix(content): read content from local files during build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@
 AGENTS.md
 biome.json
 CODE_OF_CONDUCT.md
-content
 CONTRIBUTING.md
 LICENSE
 next-env.d.ts

--- a/lib/content/loader.ts
+++ b/lib/content/loader.ts
@@ -9,7 +9,8 @@ export interface ContentLoader {
 
 export function createContentLoader(): ContentLoader {
   const source = process.env.CONTENT_SOURCE ?? "local"
-  if (source === "github") {
+  const isBuild = process.env.NEXT_PHASE === "phase-production-build"
+  if (source === "github" && !isBuild) {
     const { GitHubContentLoader } = require("./github-loader")
     return new GitHubContentLoader()
   }


### PR DESCRIPTION

The Docker/Lambda build runs with CONTENT_SOURCE=github, so
`generateStaticParams` fetched the post list from the GitHub REST API at
build time. That request is unauthenticated and rate-limited to 60 req/h
on shared CI IPs, so it returned 403; the empty result then failed the
build under Cache Components ("all generateStaticParams functions must
return at least one result").

Read content from the local filesystem during `next build` instead
(detected via NEXT_PHASE === "phase-production-build"). The posts live in
the repo, so the build no longer depends on the GitHub API. At runtime
the configured source (github) is still used for revalidation.

- lib/content/loader.ts: force the local loader during the build phase.
- .dockerignore: stop excluding `content` so the files reach the builder
  image (COPY . .). The runtime stage does not copy content, so the final
  image stays lean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
