### PR TITLE
fix: remove inert experimental.viewTransition flag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "babel-plugin-react-compiler": "experimental",
         "drizzle-kit": "0.31.10",
         "fast-check": "^4.9.0",
-        "postcss": "^8.5.22",
+        "postcss": "^8.5.23",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
       },
@@ -630,7 +630,7 @@
 
     "playwright-core": ["playwright-core@1.62.0-alpha-1783623505000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ=="],
 
-    "postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
     isrFlushToDisk: false,
-    viewTransition: true,
     useTypeScriptCli: true,
     serverActions: {
       allowedOrigins: ["kokohore56562wanwan.site"],

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "babel-plugin-react-compiler": "experimental",
     "drizzle-kit": "0.31.10",
     "fast-check": "^4.9.0",
-    "postcss": "^8.5.22",
+    "postcss": "^8.5.23",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2"
   },


### PR DESCRIPTION
next@16.3.0-canary.95 removed the experimental.viewTransition option
(vercel/next.js#96098). The flag was inert: ViewTransition ships in the
bundled React canary and Link navigations already run inside
React.startTransition, so view transitions keep working without it.

Fixes the CI build failure ('Unrecognized key(s) in object:
viewTransition' / TS2353) introduced by the dependency bump in #1090.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


## Summary

<!-- What does this PR do? Briefly describe the changes. -->

## Details

<!-- Explain the approach and any design decisions. -->

## Related Issues

<!-- Link related issues: closes #123, fixes #456 -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [ ] `bun lint:fix` passes
- [ ] `bun test:unit` passes
- [ ] `bun run build` succeeds
- [ ] E2E tests pass if applicable (`bun test:e2e`)

## Verification

<!-- How did you verify your changes? Commands run, screenshots, etc. -->

## Summary by Sourcery

Remove the deprecated experimental.viewTransition configuration flag from next.config to align with the updated Next.js canary release and resolve CI build failures caused by the unsupported option.