### PR TITLE
chore: rename workflow

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -2,15 +2,6 @@ name: 🗑️ Cleanup caches by a branch
 
 on:
   pull_request:
-    paths:
-      - "app/**"
-      - "public/**"
-      - "test/**"
-      - ".dockerignore"
-      - "bun.lock"
-      - "Dockerfile"
-      - "package.json"
-      - "*config.*"
     types:
       - closed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,18 @@ jobs:
           persist-credentials: false
 
       - name: ✅ Check if the release has already been created
-        run: echo RELEASE_EXISTS=$(gh release list | grep "$VERSION") >> $GITHUB_ENV
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: 💾 Create release
-        if: env.RELEASE_EXISTS == ''
+        if: steps.check.outputs.exists == 'false'
         run: gh release create "$VERSION" --generate-notes -t "$REPO_NAME $VERSION"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub release and cache cleanup workflows to make release creation idempotent and adjust when cache cleanup runs.

CI:
- Change the release workflow to explicitly check for an existing GitHub release via a dedicated step and conditionally create a release based on that result.
- Rename and relax the trigger conditions for the cache cleanup workflow so it runs on all closed pull requests rather than only when specific paths change.