### PR TITLE
ci: fix unit test timeout on emulated arm64 and widen test triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,32 @@ on:
   pull_request:
     paths:
       - "app/**"
+      - "components/**"
+      - "content/**"
+      - "lib/**"
       - "public/**"
       - "test/**"
       - ".dockerignore"
       - "bun.lock"
       - "Dockerfile"
+      - "mdx-components.tsx"
       - "package.json"
+      - "proxy.ts"
       - "*config.*"
   push:
     paths:
       - "app/**"
+      - "components/**"
+      - "content/**"
+      - "lib/**"
       - "public/**"
       - "test/**"
       - ".dockerignore"
       - "bun.lock"
       - "Dockerfile"
+      - "mdx-components.tsx"
       - "package.json"
+      - "proxy.ts"
       - "*config.*"
   workflow_dispatch:
 

--- a/test/unit/components/footer-privacy-link.test.tsx
+++ b/test/unit/components/footer-privacy-link.test.tsx
@@ -31,7 +31,12 @@ describe("Feature: privacy-policy-page, Property 3: フッターリンクの正�
         expect(link?.getAttribute("href")).toBe(`/${locale}/privacy-policy`)
         expect(link?.textContent).toBe(dictionary.footer.privacyPolicy)
       }),
-      { numRuns: 100 },
+      // The input domain is `locales` (2 values), so 100 runs re-tests the same
+      // inputs ~50x each without adding coverage. Each run does a full React
+      // render of Footer, which pushed this test past bun's 5s default timeout
+      // on the QEMU-emulated linux/arm64 stage of the Docker build (~20x slower
+      // than native).
+      { numRuns: 10 },
     )
   })
 })


### PR DESCRIPTION
## Summary

Fixes the 🐳 Docker CI/CD failure on `main` ([run 32822902620](https://github.com/JamBalaya56562/blog/actions/runs/32822902620/job/97724655043)) and closes a gap in the 🧪 Test workflow's path filters.

## Details

### 1. Unit test timeout on the emulated `linux/arm64` Docker stage

The Docker workflow builds `linux/amd64,linux/arm64` on push to `main`, and the arm64 stage runs under QEMU emulation. Within the same job:

| Stage | 153 tests | `Property 3: フッターリンクの正当性` |
| --- | --- | --- |
| `[linux/amd64 builder 5/6]` | 2.49s ✅ | 273.05 ms |
| `[linux/arm64 builder 5/6]` | 46.58s ❌ | **5549.31 ms** |

Emulation is ~20x slower, which pushed that one test past bun's 5000ms default timeout. The 🧪 Test workflow passed on the same commit (`08704a6`) because it runs natively; PRs only build `amd64`, so this surfaces only on push to `main`.

The test's input domain is `fc.constantFrom(...locales)` — 2 values — yet `numRuns: 100` re-rendered the whole `Footer` 100 times, re-testing the same two inputs ~50x each for zero added coverage. Reduced to `numRuns: 10`.

Measured locally (x86_64, bun 1.4.0): **1271ms → 644ms** for that file, restoring a wide margin under the timeout on emulated arm64.

### 2. Missing path filters in the Test workflow

`test.yml` and `docker.yml` had different `paths:` filters:

| Path | `test.yml` (before) | `docker.yml` |
| --- | --- | --- |
| `components/**` | ❌ | ✅ |
| `content/**` | ❌ | ✅ |
| `lib/**` | ❌ | ✅ |
| `mdx-components.tsx` | ❌ | — |
| `proxy.ts` | ❌ | — |

A change confined to `components/` or `lib/` did not trigger 🧪 Test at all, leaving the `RUN bun test:unit` step inside the Docker build as the only unit test gate. Notably, the test that failed here covers `components/footer.tsx`. `proxy.ts` has a dedicated test (`test/unit/proxy.test.ts`) but was matched by neither filter.

Added `components/**`, `content/**`, `lib/**`, `mdx-components.tsx` and `proxy.ts` to both the `pull_request` and `push` triggers.

## Related Issues

<!-- none -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] `bun lint:fix` passes
- [x] `bun test:unit` passes
- [ ] `bun run build` succeeds — not run locally (requires `DATABASE_URL`); covered by CI
- [ ] E2E tests pass if applicable (`bun test:e2e`) — not applicable

## Verification

```console
$ bun test:unit
 153 pass
 0 fail
Ran 153 tests across 35 files. [2.54s]

$ bun biome check test/unit/components/footer-privacy-link.test.tsx
Checked 1 file in 2s. No fixes applied.
```

Timing of the affected file, before vs after:

```console
# before — numRuns: 100
Ran 1 test across 1 file. [1271.00ms]

# after — numRuns: 10
Ran 1 test across 1 file. [644.00ms]
```

## Follow-up (not in this PR)

With `test.yml` now covering the same paths as `docker.yml`, the `RUN bun test:unit` step in the `Dockerfile` is redundant — it verifies nothing that is Docker- or architecture-specific, and costs ~46s of QEMU emulation per build. Removing it would need a replacement gate (a `test` job inside `docker.yml` that `build` declares `needs:`, or a required status check), since `needs:` cannot span workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent arm64 test timeouts and ensure relevant source changes consistently trigger the unit-test workflow.

Bug Fixes:
- Reduce the Footer privacy-link property test workload to prevent timeouts in emulated arm64 Docker builds.

Enhancements:
- Expand unit-test workflow path triggers to cover component, content, library, and root-level application changes.

CI:
- Ensure native unit tests run for changes that previously triggered only Docker-embedded tests.